### PR TITLE
Release v0.1.6: TOML config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2026-04-18
+
+### Added
+- TOML configuration support:
+  - Global config at `~/.deepagents/config.toml` (shared with upstream deepagents CLI)
+  - Project config at `deepagents.toml` (walks up from cwd)
+  - Project overrides global; CLI args and env vars override both
+- `[ui]` table: `verbose`, `async_mode`, `stream_mode`
+- `[agent]` table: `spec`, `graph_name`, `workspace_root`
+- `[configurable]` table seeds LangGraph `RunnableConfig.configurable`
+- `/config` slash command now shows resolved values and TOML source files
+
+### Removed
+- `--config` / `-c` CLI flag (use TOML files instead)
+- `DEEPAGENT_CONFIG` environment variable (use TOML files instead)
+
+### Breaking
+- JSON config via `--config` / `DEEPAGENT_CONFIG` is removed. Migrate inline
+  JSON into `~/.deepagents/config.toml` or a project `deepagents.toml`.
+
 ## [0.1.5] - 2026-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,8 +72,36 @@ deepagent-code
 # Working directory
 export DEEPAGENT_WORKSPACE_ROOT="/path/to/workspace"
 
-# Configuration
-export DEEPAGENT_CONFIG='{"configurable": {"thread_id": "1"}}'
+# Stream mode (updates or values)
+export DEEPAGENT_STREAM_MODE="updates"
+```
+
+## Configuration Files
+
+`deepagent-code` reads TOML config from two locations and merges them
+(project overrides global):
+
+- **Global**: `~/.deepagents/config.toml` (shared with the upstream
+  `deepagents` CLI)
+- **Project**: `deepagents.toml` in the current directory or any ancestor
+
+Precedence: CLI args > env vars > project TOML > global TOML > defaults.
+
+Example `deepagents.toml`:
+
+```toml
+[agent]
+spec = "my_agent.py:graph"
+workspace_root = "."
+
+[ui]
+verbose = true
+async_mode = false
+stream_mode = "updates"
+
+[configurable]
+# seeds LangGraph RunnableConfig.configurable
+thread_id = "my-thread"
 ```
 
 ## CLI Options
@@ -88,9 +116,9 @@ Options:
   -a, --agent TEXT                Agent spec (path/to/file.py:graph or module:graph)
   -g, --graph-name TEXT           Graph variable name (default: "graph")
   -f, --file PATH                 Read message from a file (any extension)
-  -c, --config TEXT               Config JSON or file path
   --interactive/--no-interactive  Handle interrupts (default: interactive)
   --async-mode/--sync-mode        Async streaming (default: sync)
+  --stream-mode TEXT              Stream mode (updates or values)
   -v, --verbose                   Verbose output
 ```
 

--- a/deepagent_code/cli.py
+++ b/deepagent_code/cli.py
@@ -37,6 +37,7 @@ from deepagent_code.utils import (
     stream_graph_updates,
     astream_graph_updates,
 )
+from deepagent_code import config as config_module
 
 
 # ANSI color codes (matching nanocode style)
@@ -54,7 +55,7 @@ SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇",
 
 
 # Version info
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 
 # Slash command registry
@@ -1000,40 +1001,50 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
     config = context.get("config", {})
 
     if not args:
-        # Show current config
         print(f"\n{BOLD}{BRIGHT_CYAN}Configuration{RESET}")
         print(f"{DIM}{'─' * 30}{RESET}")
-        for key, value in config.items():
-            if isinstance(value, dict):
-                print(f"  {CYAN}{key}:{RESET}")
-                for k, v in value.items():
-                    # Truncate long values
-                    v_str = str(v)
-                    if len(v_str) > 30:
-                        v_str = v_str[:30] + "..."
-                    print(f"    {DIM}{k}:{RESET} {v_str}")
-            else:
-                print(f"  {CYAN}{key}:{RESET} {value}")
+
+        sources = config.get("_toml_sources", [])
+        if sources:
+            print(f"  {DIM}TOML sources:{RESET}")
+            for src in sources:
+                print(f"    {DIM}- {src}{RESET}")
+        else:
+            print(f"  {DIM}TOML sources:{RESET} {DIM}(none — using defaults){RESET}")
+
+        print(f"  {DIM}Resolved settings:{RESET}")
+        print(f"    {CYAN}verbose:{RESET}     {context.get('verbose', False)}")
+        print(f"    {CYAN}async_mode:{RESET}  {context.get('use_async', False)}")
+        print(f"    {CYAN}stream_mode:{RESET} {context.get('stream_mode', 'updates')}")
+
+        configurable = config.get("configurable", {})
+        if configurable:
+            print(f"  {DIM}LangGraph configurable:{RESET}")
+            for k, v in configurable.items():
+                v_str = str(v)
+                if len(v_str) > 50:
+                    v_str = v_str[:50] + "..."
+                print(f"    {CYAN}{k}:{RESET} {v_str}")
         print()
     else:
         parts = args.split(maxsplit=1)
         if len(parts) == 1:
-            # Show specific config key
             key = parts[0]
-            if key in config:
-                print(f"\n{CYAN}{key}:{RESET} {config[key]}\n")
-            elif "configurable" in config and key in config["configurable"]:
-                print(f"\n{CYAN}{key}:{RESET} {config['configurable'][key]}\n")
+            configurable = config.get("configurable", {})
+            if key in configurable:
+                print(f"\n{CYAN}{key}:{RESET} {configurable[key]}\n")
+            elif key in ("verbose", "async_mode", "stream_mode"):
+                ctx_key = "use_async" if key == "async_mode" else key
+                print(f"\n{CYAN}{key}:{RESET} {context.get(ctx_key)}\n")
             else:
                 print(f"{YELLOW}Unknown config key: {key}{RESET}")
         else:
-            # Set config value
             key, value = parts
             if key == "verbose":
                 context["verbose"] = value.lower() in ("true", "1", "on", "yes")
                 print(f"{GREEN}✓ Set verbose = {context['verbose']}{RESET}")
             else:
-                print(f"{YELLOW}Cannot modify {key} at runtime{RESET}")
+                print(f"{YELLOW}Cannot modify {key} at runtime (edit deepagents.toml){RESET}")
     return None
 
 
@@ -1349,11 +1360,6 @@ def run_conversation_loop(
     help="Read input message from a file (any extension)",
 )
 @click.option(
-    "--config",
-    "-c",
-    help="Configuration JSON string or path to JSON file",
-)
-@click.option(
     "--interactive/--no-interactive",
     default=True,
     help="Handle interrupts interactively (default: True)",
@@ -1361,7 +1367,7 @@ def run_conversation_loop(
 @click.option(
     "--async-mode/--sync-mode",
     "use_async",
-    default=False,
+    default=None,
     help="Use async streaming (default: sync)",
 )
 @click.option(
@@ -1372,6 +1378,7 @@ def run_conversation_loop(
     "--verbose",
     "-v",
     is_flag=True,
+    default=None,
     help="Show verbose output including node names",
 )
 def main(
@@ -1379,11 +1386,10 @@ def main(
     agent_spec: Optional[str],
     graph_name: Optional[str],
     prompt_file: Optional[str],
-    config: Optional[str],
     interactive: bool,
-    use_async: bool,
+    use_async: Optional[bool],
     stream_mode: Optional[str],
-    verbose: bool,
+    verbose: Optional[bool],
 ):
     """
     Run a LangGraph agent from the command line.
@@ -1402,10 +1408,11 @@ def main(
     \b
     - DEEPAGENT_SPEC: Agent location (same formats as above)
     - DEEPAGENT_WORKSPACE_ROOT: Working directory for the agent
-    - DEEPAGENT_CONFIG: Configuration JSON string or path to JSON file
     - DEEPAGENT_STREAM_MODE: Stream mode for LangGraph (updates or values)
 
-    Command-line arguments override environment variables.
+    Reads ~/.deepagents/config.toml (global) and deepagents.toml (project,
+    walks up from cwd). Precedence: CLI args > env vars > project TOML >
+    global TOML > built-in defaults.
 
     \b
     Examples:
@@ -1431,15 +1438,44 @@ def main(
                 print(f"{RED}⏺ Error reading file '{prompt_file}': {e}{RESET}")
                 sys.exit(1)
 
-        # Get environment variables (DEEPAGENT_SPEC preferred, DEEPAGENT_AGENT_SPEC for backwards compat)
-        env_agent_spec = os.getenv('DEEPAGENT_SPEC') or os.getenv('DEEPAGENT_AGENT_SPEC')
-        env_workspace_root = os.getenv('DEEPAGENT_WORKSPACE_ROOT')
-        env_config = os.getenv('DEEPAGENT_CONFIG')
-        env_stream_mode = os.getenv('DEEPAGENT_STREAM_MODE', 'updates')
+        # Load TOML configuration (global + project, merged)
+        try:
+            toml_config, toml_sources = config_module.load_config()
+        except config_module.ConfigError as e:
+            print(f"{RED}⏺ {e}{RESET}")
+            sys.exit(1)
 
-        # Determine which spec to use (CLI arg > env var > default)
-        final_spec = agent_spec or env_agent_spec
-        default_graph_name = graph_name or "graph"
+        # Resolve settings with precedence: CLI > env > TOML > default
+        final_spec = config_module.resolve(
+            toml_config, "agent.spec",
+            cli_value=agent_spec,
+            env_var="DEEPAGENT_SPEC",
+        ) or os.getenv("DEEPAGENT_AGENT_SPEC")  # legacy env var
+        final_graph_name_default = config_module.resolve(
+            toml_config, "agent.graph_name",
+            cli_value=graph_name,
+            default="graph",
+        )
+        workspace_root = config_module.resolve(
+            toml_config, "agent.workspace_root",
+            env_var="DEEPAGENT_WORKSPACE_ROOT",
+        )
+        final_stream_mode = config_module.resolve(
+            toml_config, "ui.stream_mode",
+            cli_value=stream_mode,
+            env_var="DEEPAGENT_STREAM_MODE",
+            default="updates",
+        )
+        use_async = config_module.resolve(
+            toml_config, "ui.async_mode",
+            cli_value=use_async,
+            default=False,
+        )
+        verbose = config_module.resolve(
+            toml_config, "ui.verbose",
+            cli_value=verbose,
+            default=False,
+        )
 
         # If no spec provided, try the default agent
         if not final_spec:
@@ -1455,44 +1491,28 @@ def main(
                 sys.exit(1)
 
         # Change to workspace root if specified
-        if env_workspace_root:
-            workspace_path = Path(env_workspace_root).resolve()
+        if workspace_root:
+            workspace_path = Path(workspace_root).expanduser().resolve()
             if workspace_path.exists():
                 os.chdir(workspace_path)
 
         # Load the graph with a spinner
         spinner = Spinner("Loading agent")
         spinner.start()
-        graph, final_graph_name = load_graph(final_spec, default_graph_name)
+        graph, final_graph_name = load_graph(final_spec, final_graph_name_default)
         spinner.stop()
         print(f"{GREEN}✓{RESET} {DIM}Loaded {final_spec}{RESET}")
 
-        # Parse config
-        config_dict = None
-        config_source = config or env_config
-
-        if config_source:
-            config_path = Path(config_source)
-            if config_path.exists():
-                with open(config_path) as f:
-                    config_dict = json.load(f)
-            else:
-                try:
-                    config_dict = json.loads(config_source)
-                except json.JSONDecodeError as e:
-                    print(f"{RED}⏺ Invalid config JSON: {e}{RESET}")
-                    sys.exit(1)
-
-        # Get stream mode
-        final_stream_mode = stream_mode or env_stream_mode
-
-        # Ensure config has a thread_id for checkpointer support
-        if config_dict is None:
-            config_dict = {}
-        if "configurable" not in config_dict:
-            config_dict["configurable"] = {}
+        # Seed LangGraph RunnableConfig from TOML [configurable] table if present
+        config_dict: Dict[str, Any] = {"configurable": {}}
+        toml_configurable = config_module.get(toml_config, "configurable")
+        if isinstance(toml_configurable, dict):
+            config_dict["configurable"].update(toml_configurable)
         if "thread_id" not in config_dict["configurable"]:
             config_dict["configurable"]["thread_id"] = str(uuid.uuid4())
+
+        # Expose TOML sources to slash commands via the config dict
+        config_dict["_toml_sources"] = [str(p) for p in toml_sources]
 
         # Extract agent name and description from graph object
         agent_name = get_agent_name(graph)

--- a/deepagent_code/config.py
+++ b/deepagent_code/config.py
@@ -1,0 +1,113 @@
+"""TOML configuration loader for deepagent-code.
+
+Reads two files and merges them (project wins on conflict):
+- ~/.deepagents/config.toml — shared with the upstream deepagents CLI
+- deepagents.toml — nearest ancestor of cwd, per-project overrides
+"""
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+GLOBAL_CONFIG_PATH = Path.home() / ".deepagents" / "config.toml"
+PROJECT_CONFIG_NAME = "deepagents.toml"
+
+
+class ConfigError(Exception):
+    """Raised when a config file exists but cannot be parsed."""
+
+
+def global_config_path() -> Path:
+    override = os.getenv("DEEPAGENTS_CONFIG_HOME")
+    if override:
+        return Path(override).expanduser() / "config.toml"
+    return GLOBAL_CONFIG_PATH
+
+
+def find_project_config(start: Optional[Path] = None) -> Optional[Path]:
+    """Walk up from `start` (or cwd) looking for deepagents.toml."""
+    here = (start or Path.cwd()).resolve()
+    for directory in (here, *here.parents):
+        candidate = directory / PROJECT_CONFIG_NAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _read_toml(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigError(f"Invalid TOML in {path}: {e}") from e
+
+
+def _deep_merge(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge overlay into base. Overlay wins on leaf conflicts."""
+    result = dict(base)
+    for key, value in overlay.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_config(start: Optional[Path] = None) -> Tuple[Dict[str, Any], List[Path]]:
+    """Load global + project TOML, merged. Returns (config, sources_used)."""
+    sources: List[Path] = []
+    merged: Dict[str, Any] = {}
+
+    gpath = global_config_path()
+    if gpath.exists():
+        merged = _deep_merge(merged, _read_toml(gpath))
+        sources.append(gpath)
+
+    ppath = find_project_config(start)
+    if ppath is not None:
+        merged = _deep_merge(merged, _read_toml(ppath))
+        sources.append(ppath)
+
+    return merged, sources
+
+
+def get(config: Dict[str, Any], dotted_key: str, default: Any = None) -> Any:
+    """Fetch a nested value via dotted path, e.g. 'ui.verbose'."""
+    node: Any = config
+    for part in dotted_key.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return node
+
+
+def resolve(
+    config: Dict[str, Any],
+    dotted_key: str,
+    cli_value: Any = None,
+    env_var: Optional[str] = None,
+    default: Any = None,
+    cast: Optional[type] = None,
+) -> Any:
+    """Resolve a value with precedence: CLI > env > TOML > default."""
+    if cli_value is not None:
+        return cli_value
+    if env_var:
+        env_value = os.getenv(env_var)
+        if env_value is not None:
+            if cast is bool:
+                return env_value.lower() in ("1", "true", "yes", "on")
+            if cast is not None:
+                return cast(env_value)
+            return env_value
+    toml_value = get(config, dotted_key)
+    if toml_value is not None:
+        return toml_value
+    return default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepagent-code"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Claude Code-style CLI for running LangGraph agents from the terminal"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,113 @@
+"""Tests for deepagent_code.config."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deepagent_code import config
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_returns_empty_when_no_files(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.chdir(tmp_path)
+    cfg, sources = config.load_config()
+    assert cfg == {}
+    assert sources == []
+
+
+def test_loads_global_only(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    _write(home / "config.toml", '[ui]\nverbose = true\n')
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    cfg, sources = config.load_config()
+    assert cfg == {"ui": {"verbose": True}}
+    assert sources == [home / "config.toml"]
+
+
+def test_loads_project_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(tmp_path / "empty"))
+    project = tmp_path / "proj"
+    _write(project / "deepagents.toml", '[agent]\nspec = "foo.py:agent"\n')
+    monkeypatch.chdir(project)
+    cfg, sources = config.load_config()
+    assert cfg == {"agent": {"spec": "foo.py:agent"}}
+    assert sources == [project / "deepagents.toml"]
+
+
+def test_project_overrides_global(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    _write(home / "config.toml", '[ui]\nverbose = false\nstream_mode = "values"\n')
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(home))
+
+    project = tmp_path / "proj"
+    _write(project / "deepagents.toml", '[ui]\nverbose = true\n')
+    monkeypatch.chdir(project)
+
+    cfg, sources = config.load_config()
+    # project wins on overlapping keys, global keys still present
+    assert cfg == {"ui": {"verbose": True, "stream_mode": "values"}}
+    assert sources == [home / "config.toml", project / "deepagents.toml"]
+
+
+def test_walks_up_for_project_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(tmp_path / "empty"))
+    project = tmp_path / "proj"
+    nested = project / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    _write(project / "deepagents.toml", '[ui]\nverbose = true\n')
+    monkeypatch.chdir(nested)
+
+    cfg, sources = config.load_config()
+    assert cfg == {"ui": {"verbose": True}}
+    assert sources == [project / "deepagents.toml"]
+
+
+def test_invalid_toml_raises(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    _write(home / "config.toml", "this is = not = valid toml\n")
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(config.ConfigError):
+        config.load_config()
+
+
+def test_get_dotted_path():
+    data = {"ui": {"verbose": True}, "agent": {"spec": "x"}}
+    assert config.get(data, "ui.verbose") is True
+    assert config.get(data, "agent.spec") == "x"
+    assert config.get(data, "missing") is None
+    assert config.get(data, "ui.missing", default="d") == "d"
+    assert config.get(data, "ui.verbose.nested", default="d") == "d"
+
+
+def test_resolve_precedence(monkeypatch):
+    cfg = {"ui": {"verbose": True}}
+    monkeypatch.delenv("UI_VERBOSE", raising=False)
+
+    # default only
+    assert config.resolve({}, "ui.verbose", default=False) is False
+    # toml beats default
+    assert config.resolve(cfg, "ui.verbose", default=False) is True
+    # env beats toml
+    monkeypatch.setenv("UI_VERBOSE", "false")
+    assert config.resolve(cfg, "ui.verbose", env_var="UI_VERBOSE", cast=bool) is False
+    # cli beats env
+    assert config.resolve(
+        cfg, "ui.verbose", cli_value=True, env_var="UI_VERBOSE", cast=bool
+    ) is True
+
+
+def test_resolve_bool_cast(monkeypatch):
+    for truthy in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("X", truthy)
+        assert config.resolve({}, "missing", env_var="X", cast=bool) is True
+    for falsy in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv("X", falsy)
+        assert config.resolve({}, "missing", env_var="X", cast=bool) is False

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "deepagent-code"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds TOML configuration loader reading `~/.deepagents/config.toml` (global, shared with upstream `deepagents` CLI) and `deepagents.toml` (project, walks up from cwd)
- Removes `--config` / `-c` flag and `DEEPAGENT_CONFIG` env var in favor of TOML files
- `/config` slash command now shows resolved settings and source files

## Test plan
- [x] 9 new tests in `tests/test_config.py` cover merge order, missing files, malformed TOML, dotted-key resolution, precedence
- [x] Full suite: 69/69 passing
- [x] CLI smoke test with no TOML files present — boots, loads default agent