### PR TITLE
Adopt shared HostConfig + reconcile DEEPAGENT_AGENT_SPEC

### DIFF
--- a/deepagent_code/cli.py
+++ b/deepagent_code/cli.py
@@ -940,10 +940,11 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
         else:
             print(f"  {DIM}TOML sources:{RESET} {DIM}(none — using defaults){RESET}")
 
-        print(f"  {DIM}Resolved settings:{RESET}")
-        print(f"    {CYAN}verbose:{RESET}     {context.get('verbose', False)}")
-        print(f"    {CYAN}async_mode:{RESET}  {context.get('use_async', False)}")
-        print(f"    {CYAN}stream_mode:{RESET} {context.get('stream_mode', 'updates')}")
+        # Full resolved view: each value, where it came from, and the env var
+        # / TOML key that sets it.
+        from deepagent_code.config import CodeConfig
+        for line in CodeConfig.resolve().describe().splitlines():
+            print(f"  {line}")
 
         configurable = config.get("configurable", {})
         if configurable:
@@ -1334,7 +1335,8 @@ def main(
     Supports environment variables for configuration:
 
     \b
-    - DEEPAGENT_SPEC: Agent location (same formats as above)
+    - DEEPAGENT_AGENT_SPEC: Agent location (same formats as above).
+      (DEEPAGENT_SPEC is still accepted as a deprecated alias.)
     - DEEPAGENT_WORKSPACE_ROOT: Working directory for the agent
     - DEEPAGENT_STREAM_MODE: Stream mode for LangGraph (updates or values)
 
@@ -1373,36 +1375,31 @@ def main(
             print(f"{RED}⏺ {e}{RESET}")
             sys.exit(1)
 
-        # Resolve settings with precedence: CLI > env > TOML > default
-        final_spec = config_module.resolve(
-            toml_config, "agent.spec",
-            cli_value=agent_spec,
-            env_var="DEEPAGENT_SPEC",
-        ) or os.getenv("DEEPAGENT_AGENT_SPEC")  # legacy env var
-        final_graph_name_default = config_module.resolve(
-            toml_config, "agent.graph_name",
-            cli_value=graph_name,
-            default="graph",
+        # Resolve all standard settings through the shared chain in one shot:
+        # CLI overrides > DEEPAGENT_* env > deepagents.toml > defaults.
+        # (DEEPAGENT_AGENT_SPEC is canonical; DEEPAGENT_SPEC is a deprecated alias.)
+        cfg = config_module.CodeConfig.resolve(
+            toml_start=Path.cwd(),
+            overrides={
+                "agent_spec": agent_spec,
+                "graph_name": graph_name,
+                "stream_mode": stream_mode,
+                # bool flags only override when actually passed; otherwise fall
+                # back to TOML/env/default.
+                "async_mode": True if use_async else None,
+                "verbose": True if verbose else None,
+            },
         )
-        workspace_root = config_module.resolve(
-            toml_config, "agent.workspace_root",
-            env_var="DEEPAGENT_WORKSPACE_ROOT",
-        )
-        final_stream_mode = config_module.resolve(
-            toml_config, "ui.stream_mode",
-            cli_value=stream_mode,
-            env_var="DEEPAGENT_STREAM_MODE",
-            default="updates",
-        )
-        use_async = config_module.resolve(
-            toml_config, "ui.async_mode",
-            cli_value=use_async,
-            default=False,
-        )
-        verbose = config_module.resolve(
-            toml_config, "ui.verbose",
-            cli_value=verbose,
-            default=False,
+        final_spec = cfg.agent_spec
+        final_graph_name_default = cfg.graph_name
+        final_stream_mode = cfg.stream_mode
+        use_async = cfg.async_mode
+        verbose = cfg.verbose
+        # Only change directory when a workspace root was actually configured.
+        workspace_root = (
+            cfg.workspace_root
+            if cfg.sources.get("workspace_root") != "default"
+            else None
         )
 
         # If no spec provided, try the default agent
@@ -1415,7 +1412,7 @@ def main(
                 print(f"\n{DIM}Usage:{RESET}")
                 print(f"  deepagent-code path/to/agent.py:graph")
                 print(f"  deepagent-code mypackage.module:agent")
-                print(f"\n{DIM}Or set DEEPAGENT_SPEC environment variable{RESET}")
+                print(f"\n{DIM}Or set DEEPAGENT_AGENT_SPEC environment variable{RESET}")
                 sys.exit(1)
 
         # Change to workspace root if specified

--- a/deepagent_code/config.py
+++ b/deepagent_code/config.py
@@ -1,85 +1,42 @@
-"""TOML configuration loader for deepagent-code.
+"""Configuration for deepagent-code.
 
-Reads two files and merges them (project wins on conflict):
-- ~/.deepagents/config.toml — shared with the upstream deepagents CLI
-- deepagents.toml — nearest ancestor of cwd, per-project overrides
+Shares the TOML loader and the ``DEEPAGENT_*`` schema with the rest of the
+deep-agent family via ``langgraph_stream_parser.host``: global
+``~/.deepagents/config.toml`` + project ``deepagents.toml`` (merged), then env
+vars, then CLI overrides.
+
+``CodeConfig`` is deepagent-code's view of that shared config. ``load_config`` /
+``get`` / ``resolve`` remain for the ``[configurable]`` passthrough and ad-hoc
+lookups.
 """
-from __future__ import annotations
-
 import os
 import tomllib
+import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, List, Optional, Tuple
 
-
-GLOBAL_CONFIG_PATH = Path.home() / ".deepagents" / "config.toml"
-PROJECT_CONFIG_NAME = "deepagents.toml"
+from langgraph_stream_parser.host import HostConfig, load_toml_config
 
 
 class ConfigError(Exception):
     """Raised when a config file exists but cannot be parsed."""
 
 
-def global_config_path() -> Path:
-    override = os.getenv("DEEPAGENTS_CONFIG_HOME")
-    if override:
-        return Path(override).expanduser() / "config.toml"
-    return GLOBAL_CONFIG_PATH
+def load_config(start: Optional[Path] = None) -> Tuple[dict, List[Path]]:
+    """Load global + project ``deepagents.toml``, merged (project wins).
 
-
-def find_project_config(start: Optional[Path] = None) -> Optional[Path]:
-    """Walk up from `start` (or cwd) looking for deepagents.toml."""
-    here = (start or Path.cwd()).resolve()
-    for directory in (here, *here.parents):
-        candidate = directory / PROJECT_CONFIG_NAME
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def _read_toml(path: Path) -> Dict[str, Any]:
+    Delegates to the shared loader so every deep-agent tool reads the same
+    files with the same precedence. Returns ``(config, sources_used)``.
+    """
     try:
-        with path.open("rb") as f:
-            return tomllib.load(f)
+        return load_toml_config(start)
     except tomllib.TOMLDecodeError as e:
-        raise ConfigError(f"Invalid TOML in {path}: {e}") from e
+        raise ConfigError(f"Invalid TOML: {e}") from e
 
 
-def _deep_merge(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively merge overlay into base. Overlay wins on leaf conflicts."""
-    result = dict(base)
-    for key, value in overlay.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
-            result[key] = _deep_merge(result[key], value)
-        else:
-            result[key] = value
-    return result
-
-
-def load_config(start: Optional[Path] = None) -> Tuple[Dict[str, Any], List[Path]]:
-    """Load global + project TOML, merged. Returns (config, sources_used)."""
-    sources: List[Path] = []
-    merged: Dict[str, Any] = {}
-
-    gpath = global_config_path()
-    if gpath.exists():
-        merged = _deep_merge(merged, _read_toml(gpath))
-        sources.append(gpath)
-
-    ppath = find_project_config(start)
-    if ppath is not None:
-        merged = _deep_merge(merged, _read_toml(ppath))
-        sources.append(ppath)
-
-    return merged, sources
-
-
-def get(config: Dict[str, Any], dotted_key: str, default: Any = None) -> Any:
-    """Fetch a nested value via dotted path, e.g. 'ui.verbose'."""
+def get(config: dict, dotted_key: str, default: Any = None) -> Any:
+    """Fetch a nested value via dotted path, e.g. ``'ui.verbose'``."""
     node: Any = config
     for part in dotted_key.split("."):
         if not isinstance(node, dict) or part not in node:
@@ -89,14 +46,18 @@ def get(config: Dict[str, Any], dotted_key: str, default: Any = None) -> Any:
 
 
 def resolve(
-    config: Dict[str, Any],
+    config: dict,
     dotted_key: str,
     cli_value: Any = None,
     env_var: Optional[str] = None,
     default: Any = None,
     cast: Optional[type] = None,
 ) -> Any:
-    """Resolve a value with precedence: CLI > env > TOML > default."""
+    """Resolve a single value with precedence: CLI > env > TOML > default.
+
+    Retained for ad-hoc lookups (e.g. the ``[configurable]`` table); the
+    standard keys resolve via :class:`CodeConfig`.
+    """
     if cli_value is not None:
         return cli_value
     if env_var:
@@ -111,3 +72,42 @@ def resolve(
     if toml_value is not None:
         return toml_value
     return default
+
+
+@dataclass
+class CodeConfig(HostConfig):
+    """deepagent-code's view of the shared config.
+
+    Adds the CLI-specific keys on top of ``HostConfig``'s shared ones, resolved
+    through the same ``defaults < deepagents.toml < DEEPAGENT_* env <
+    overrides`` chain. ``DEEPAGENT_AGENT_SPEC`` is canonical;
+    ``DEEPAGENT_SPEC`` is a deprecated alias.
+    """
+
+    stream_mode: str = "updates"
+    graph_name: str = "graph"
+    verbose: bool = False
+    async_mode: bool = False
+
+    _ENV: ClassVar[dict] = {
+        "stream_mode": ("DEEPAGENT_STREAM_MODE", str),
+    }
+    _TOML: ClassVar[dict] = {
+        "stream_mode": "ui.stream_mode",
+        "graph_name": "agent.graph_name",
+        "verbose": "ui.verbose",
+        "async_mode": "ui.async_mode",
+    }
+
+    @classmethod
+    def resolve(cls, *, env: Optional[dict] = None, **kwargs: Any) -> "CodeConfig":
+        env = dict(os.environ if env is None else env)
+        # Reconcile the legacy spec var — DEEPAGENT_AGENT_SPEC is canonical.
+        if not env.get("DEEPAGENT_AGENT_SPEC") and env.get("DEEPAGENT_SPEC"):
+            env["DEEPAGENT_AGENT_SPEC"] = env["DEEPAGENT_SPEC"]
+            warnings.warn(
+                "DEEPAGENT_SPEC is deprecated; use DEEPAGENT_AGENT_SPEC.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().resolve(env=env, **kwargs)

--- a/tests/test_codeconfig.py
+++ b/tests/test_codeconfig.py
@@ -1,0 +1,76 @@
+"""Tests for CodeConfig — deepagent-code's HostConfig subclass."""
+from pathlib import Path
+
+import pytest
+
+from deepagent_code.config import CodeConfig
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(empty))
+    return tmp_path
+
+
+def _toml(d: Path, body: str) -> None:
+    (d / "deepagents.toml").write_text(body)
+
+
+def test_defaults(isolated, tmp_path):
+    cfg = CodeConfig.resolve(env={}, toml_start=tmp_path)
+    assert cfg.stream_mode == "updates"
+    assert cfg.graph_name == "graph"
+    assert cfg.verbose is False
+    assert cfg.async_mode is False
+    assert cfg.agent_spec is None
+
+
+def test_env_stream_mode(isolated, tmp_path):
+    cfg = CodeConfig.resolve(env={"DEEPAGENT_STREAM_MODE": "values"}, toml_start=tmp_path)
+    assert cfg.stream_mode == "values"
+    assert cfg.sources["stream_mode"] == "env:DEEPAGENT_STREAM_MODE"
+
+
+def test_toml_keys(isolated, tmp_path):
+    _toml(tmp_path,
+          '[agent]\nspec = "a.py:g"\ngraph_name = "myg"\n'
+          '[ui]\nverbose = true\nasync_mode = true\nstream_mode = "values"\n')
+    cfg = CodeConfig.resolve(env={}, toml_start=tmp_path)
+    assert cfg.agent_spec == "a.py:g"
+    assert cfg.graph_name == "myg"
+    assert cfg.verbose is True
+    assert cfg.async_mode is True
+    assert cfg.stream_mode == "values"
+
+
+def test_deepagent_spec_alias_is_deprecated(isolated, tmp_path):
+    with pytest.warns(DeprecationWarning):
+        cfg = CodeConfig.resolve(env={"DEEPAGENT_SPEC": "legacy.py:g"}, toml_start=tmp_path)
+    assert cfg.agent_spec == "legacy.py:g"
+
+
+def test_canonical_var_beats_alias(isolated, tmp_path):
+    cfg = CodeConfig.resolve(
+        env={"DEEPAGENT_AGENT_SPEC": "new.py:g", "DEEPAGENT_SPEC": "old.py:g"},
+        toml_start=tmp_path,
+    )
+    assert cfg.agent_spec == "new.py:g"
+
+
+def test_overrides_win(isolated, tmp_path):
+    cfg = CodeConfig.resolve(
+        env={"DEEPAGENT_STREAM_MODE": "values"},
+        overrides={"stream_mode": "updates"},
+        toml_start=tmp_path,
+    )
+    assert cfg.stream_mode == "updates"
+    assert cfg.sources["stream_mode"] == "override"
+
+
+def test_describe_lists_var_names(isolated, tmp_path):
+    text = CodeConfig.resolve(env={}, toml_start=tmp_path).describe()
+    assert "DEEPAGENT_AGENT_SPEC" in text
+    assert "DEEPAGENT_STREAM_MODE" in text
+    assert "stream_mode" in text


### PR DESCRIPTION
First host to adopt the unified config layer (langgraph-stream-parser#11). Streamlines env/config so there's one resolution chain and one place to look.

> Stacked on #8 (`feat/shared-runtime`). Merge order: parser #10 → #11 → release → this repo's #8 → this PR. GitHub will retarget to `main` as the bases merge.

## Changes
- `config.load_config` delegates to `host.load_toml_config` — the duplicated TOML loader internals are gone; same `~/.deepagents/config.toml` + `deepagents.toml` files and precedence.
- **`CodeConfig(HostConfig)`** resolves the shared keys + the CLI-specific `stream_mode` / `graph_name` / `verbose` / `async_mode` through one chain: `defaults < deepagents.toml < DEEPAGENT_* env < CLI overrides`.
- **Name reconcile:** `DEEPAGENT_AGENT_SPEC` is now canonical; `DEEPAGENT_SPEC` is a deprecated alias (warns once). The CLI's six per-field `resolve()` calls collapse into one `CodeConfig.resolve()`.
- **`/config`** prints the resolved config with each value's source + the env var and TOML key that sets it:

```
agent_spec  = ./agent.py:graph  [env:DEEPAGENT_AGENT_SPEC]  (env: DEEPAGENT_AGENT_SPEC, toml: agent.spec)
stream_mode = values            [env:DEEPAGENT_STREAM_MODE]  (env: DEEPAGENT_STREAM_MODE, toml: ui.stream_mode)
```

## Behavior notes
- The workspace TOML key moves from `agent.workspace_root` → the shared `workspace.root`.
- `verbose`/`async_mode` flags now fall back to TOML/env when the flag isn't passed (previously the absent flag's `False` always won).

## Tests
25 pass (existing config/cli + new `test_codeconfig`).