### PR TITLE
Add --demo (keyless) + --show-config; family README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A Claude Code-style CLI for running LangGraph agents from the terminal.
 
 ![deepagent-code](examples/image.png)
 
+## One agent, every surface
+
+deepagent-code is the terminal surface of the **deep-agent family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every surface with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `deepagents.toml` config file, and the same `DEEPAGENT_*` environment variables.
+
+| Surface | Package | Try it |
+|---|---|---|
+| Web app | [cowork-dash](https://github.com/dkedar7/cowork-dash) | `cowork-dash run --agent my_agent.py:graph` |
+| JupyterLab | [deepagent-lab](https://github.com/dkedar7/deepagent-lab) | `pip install deepagent-lab`, then the chat sidebar in `jupyter lab` |
+| Terminal | deepagent-code | **you are here** |
+| VS Code | [deepagent-vscode](https://github.com/dkedar7/deepagent-vscode) | chat participant + stdio sidecar |
+| Reference agent | [deepagent-hermes](https://github.com/dkedar7/deepagent-hermes) | `DEEPAGENT_AGENT_SPEC=deepagent_hermes.agent:graph` on any surface |
+| Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every surface |
+
 ## Installation
 
 ```bash
@@ -16,6 +29,11 @@ pip install git+https://github.com/dkedar7/deepagent-code.git
 ```
 
 ## Quick Start
+
+No agent or API key yet? See the CLI working in one command:
+```bash
+deepagent-code --demo "hello"
+```
 
 Run with the default agent (requires `ANTHROPIC_API_KEY`):
 ```bash
@@ -53,6 +71,13 @@ deepagent-code --no-interactive
 
 # Verbose output
 deepagent-code -v
+
+# Keyless demo agent (no API key needed)
+deepagent-code --demo
+
+# Print the resolved configuration: each value, its source, and the
+# env var / deepagents.toml key that sets it
+deepagent-code --show-config
 ```
 
 ## Commands
@@ -66,7 +91,8 @@ In the interactive loop:
 
 ```bash
 # Agent location (path/to/file.py:variable_name or module:variable)
-export DEEPAGENT_SPEC="my_agent.py:graph"
+# (DEEPAGENT_SPEC is still accepted as a deprecated alias)
+export DEEPAGENT_AGENT_SPEC="my_agent.py:graph"
 deepagent-code
 
 # Working directory

--- a/deepagent_code/cli.py
+++ b/deepagent_code/cli.py
@@ -1339,6 +1339,19 @@ def run_conversation_loop(
     default=None,
     help="Show verbose output including node names",
 )
+@click.option(
+    "--demo",
+    is_flag=True,
+    default=False,
+    help="Run with the built-in keyless demo agent — no API key needed",
+)
+@click.option(
+    "--show-config",
+    "show_config",
+    is_flag=True,
+    default=False,
+    help="Print the resolved configuration (defaults < deepagents.toml < env < CLI) and exit",
+)
 def main(
     message: Optional[str],
     agent_spec: Optional[str],
@@ -1348,6 +1361,8 @@ def main(
     use_async: Optional[bool],
     stream_mode: Optional[str],
     verbose: Optional[bool],
+    demo: bool,
+    show_config: bool,
 ):
     """
     Run a LangGraph agent from the command line.
@@ -1379,7 +1394,20 @@ def main(
         deepagent-code -a my_agent.py "What can you do?"
         deepagent-code -a my_agent.py:graph
         deepagent-code -f ./prompt.md
+        deepagent-code --demo "try it with no API key"
+        deepagent-code --show-config
     """
+    if show_config:
+        print(config_module.CodeConfig.resolve(toml_start=Path.cwd()).describe())
+        return
+
+    if demo:
+        if agent_spec:
+            print(f"{RED}⏺ Error: --demo and -a/--agent are mutually exclusive{RESET}")
+            sys.exit(1)
+        # The keyless echo agent shipped with the shared core.
+        agent_spec = "langgraph_stream_parser.demo.stub:graph"
+
     try:
         # Handle -f/--file option: read message from file
         if prompt_file and message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "langgraph>=0.2.0",
-    "langgraph-stream-parser>=0.2,<0.3",
+    "langgraph-stream-parser>=0.2.2,<0.3",
     "click>=8.0.0",
     "python-dotenv",
     "deepagents",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,32 @@
 """Tests for CLI functions."""
 
 import pytest
-from deepagent_code.cli import parse_agent_spec
+from click.testing import CliRunner
+
+from deepagent_code.cli import main, parse_agent_spec
+
+
+class TestCliFlags:
+    """Tests for --show-config and --demo."""
+
+    def test_show_config_prints_resolved_config(self):
+        result = CliRunner().invoke(main, ["--show-config"])
+        assert result.exit_code == 0, result.output
+        assert "DEEPAGENT_AGENT_SPEC" in result.output
+
+    def test_demo_and_agent_are_mutually_exclusive(self):
+        result = CliRunner().invoke(main, ["--demo", "-a", "x.py:g", "hi"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_demo_replies_without_any_key(self, monkeypatch):
+        # A full one-shot turn through the real stub agent — proves --demo
+        # works on a machine with no API keys configured.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = CliRunner().invoke(main, ["--demo", "--no-interactive", "hello demo"])
+        assert result.exit_code == 0, result.output
+        assert "hello demo" in result.output
 
 
 class TestParseAgentSpec:


### PR DESCRIPTION
## What

- **`--demo`** — runs the CLI against the shared keyless echo stub (`langgraph_stream_parser.demo.stub:graph`): a real compiled LangGraph graph streaming through the normal parser path, but with no API key and no network. Mutually exclusive with `-a/--agent`.
- **`--show-config`** — prints the resolved `CodeConfig` (defaults < `deepagents.toml` < `DEEPAGENT_*` env < CLI), each value with its source and the key that sets it.
- README: *One agent, every surface* family table, `--demo`/`--show-config` docs, and the env-var section now documents canonical `DEEPAGENT_AGENT_SPEC` (the legacy `DEEPAGENT_SPEC` it showed is a deprecated alias).
- Parser pin bumped to `>=0.2.2,<0.3` (the release that ships the stub).

## Why

P0 usability batch: a new user should see the surface working before configuring an agent or keys, and never have to remember variable names.

## Tests

3 new CLI tests, including a full one-shot `--demo` turn with all API-key env vars stripped. Suite: 28 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)