### PR TITLE
Rename: deepagent-code becomes langstage-cli (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-06-10
+
+**deepagent-code is now `langstage-cli`** — the terminal stage of the LangStage family ("every stage for your LangGraph agent"). Repositioned as the generic terminal runner for *any* LangGraph `CompiledGraph` (LangChain's `dcode` owns the batteries-included coding-agent niche; this tool runs *your* agent).
+
+### Changed
+- Distribution `deepagent-code` → **`langstage-cli`**; module `deepagent_code` → **`langstage_cli`**. A deprecated alias package keeps `import deepagent_code` (and its submodules) working with a `DeprecationWarning`; the `deepagent-code` command remains as an alias of the new `langstage-cli` command.
+- Canonical config vocabulary via langgraph-stream-parser 0.3: `LANGSTAGE_*` env vars, project `langstage.toml`, global `~/.langstage/config.toml`. The full legacy vocabulary (`DEEPAGENT_*`, `deepagents.toml`, `~/.deepagents/`) still resolves as a deprecated fallback — and exiting `~/.deepagents/` ends the config-schema collision with LangChain's dcode.
+- Parser pinned `>=0.3,<0.4`.
+
 ## [0.3.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,49 +1,51 @@
-# deepagent-code
+# langstage-cli
 
-A Claude Code-style CLI for running LangGraph agents from the terminal.
+**The terminal stage for your LangGraph agent.** A Claude Code-style CLI that runs *any* LangGraph `CompiledGraph` — yours, not a bundled one — with streaming, tool-call rendering, and human-in-the-loop approval.
 
-![deepagent-code](examples/image.png)
+> Renamed from **deepagent-code** (the old package name now just installs this one, and the `deepagent-code` command still works).
 
-## One agent, every surface
+![langstage-cli](examples/image.png)
 
-deepagent-code is the terminal surface of the **deep-agent family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every surface with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `deepagents.toml` config file, and the same `DEEPAGENT_*` environment variables.
+## Every stage for your LangGraph agent
 
-| Surface | Package | Try it |
+langstage-cli is the terminal stage of the **LangStage family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every stage with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `langstage.toml` config file, and the same `LANGSTAGE_*` environment variables.
+
+| Stage | Package | Try it |
 |---|---|---|
-| Web app | [cowork-dash](https://github.com/dkedar7/cowork-dash) | `cowork-dash run --agent my_agent.py:graph` |
-| JupyterLab | [deepagent-lab](https://github.com/dkedar7/deepagent-lab) | `pip install deepagent-lab`, then the chat sidebar in `jupyter lab` |
-| Terminal | deepagent-code | **you are here** |
-| VS Code | [deepagent-vscode](https://github.com/dkedar7/deepagent-vscode) | chat participant + stdio sidecar |
-| Reference agent | [deepagent-hermes](https://github.com/dkedar7/deepagent-hermes) | `DEEPAGENT_AGENT_SPEC=deepagent_hermes.agent:graph` on any surface |
-| Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every surface |
+| Web app | [langstage](https://github.com/dkedar7/langstage) | `langstage run --agent my_agent.py:graph` |
+| JupyterLab | [langstage-jupyter](https://github.com/dkedar7/langstage-jupyter) | `pip install langstage-jupyter`, then the chat sidebar in `jupyter lab` |
+| Terminal | langstage-cli | **you are here** |
+| VS Code | [langstage-vscode](https://github.com/dkedar7/langstage-vscode) | chat participant + stdio sidecar |
+| Reference agent | [langstage-hermes](https://github.com/dkedar7/langstage-hermes) | `LANGSTAGE_AGENT_SPEC=langstage_hermes.agent:graph` on any stage |
+| Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every stage |
 
 ## Installation
 
 ```bash
-pip install deepagent-code
+pip install langstage-cli
 ```
 
 Or install directly from GitHub:
 ```bash
-pip install git+https://github.com/dkedar7/deepagent-code.git
+pip install git+https://github.com/dkedar7/langstage-cli.git
 ```
 
 ## Quick Start
 
 No agent or API key yet? See the CLI working in one command:
 ```bash
-deepagent-code --demo "hello"
+langstage-cli --demo "hello"
 ```
 
 Run with the default agent (requires `ANTHROPIC_API_KEY`):
 ```bash
 export ANTHROPIC_API_KEY="your_api_key"
-deepagent-code
+langstage-cli
 ```
 
 Or specify your own agent:
 ```bash
-deepagent-code -a path/to/your_agent.py:graph
+langstage-cli -a path/to/your_agent.py:graph
 ```
 
 This launches an interactive conversation loop with your agent.
@@ -52,32 +54,32 @@ This launches an interactive conversation loop with your agent.
 
 ```bash
 # Use the default agent
-deepagent-code
+langstage-cli
 
 # Send a message directly
-deepagent-code "Hello, agent!"
+langstage-cli "Hello, agent!"
 
 # Specify a custom agent file
-deepagent-code -a my_agent.py:graph
+langstage-cli -a my_agent.py:graph
 
 # Use a module path
-deepagent-code -a mypackage.agents:chatbot
+langstage-cli -a mypackage.agents:chatbot
 
 # Read message from a file
-deepagent-code -f ./prompt.md
+langstage-cli -f ./prompt.md
 
 # Non-interactive mode (auto-approve tool calls)
-deepagent-code --no-interactive
+langstage-cli --no-interactive
 
 # Verbose output
-deepagent-code -v
+langstage-cli -v
 
 # Keyless demo agent (no API key needed)
-deepagent-code --demo
+langstage-cli --demo
 
 # Print the resolved configuration: each value, its source, and the
-# env var / deepagents.toml key that sets it
-deepagent-code --show-config
+# env var / langstage.toml key that sets it
+langstage-cli --show-config
 ```
 
 ## Commands
@@ -91,29 +93,32 @@ In the interactive loop:
 
 ```bash
 # Agent location (path/to/file.py:variable_name or module:variable)
-# (DEEPAGENT_SPEC is still accepted as a deprecated alias)
-export DEEPAGENT_AGENT_SPEC="my_agent.py:graph"
-deepagent-code
+# (DEEPAGENT_AGENT_SPEC / DEEPAGENT_SPEC still accepted as deprecated aliases)
+export LANGSTAGE_AGENT_SPEC="my_agent.py:graph"
+langstage-cli
 
 # Working directory
-export DEEPAGENT_WORKSPACE_ROOT="/path/to/workspace"
+export LANGSTAGE_WORKSPACE_ROOT="/path/to/workspace"
 
 # Stream mode (updates or values)
-export DEEPAGENT_STREAM_MODE="updates"
+export LANGSTAGE_STREAM_MODE="updates"
 ```
 
 ## Configuration Files
 
-`deepagent-code` reads TOML config from two locations and merges them
+`langstage-cli` reads TOML config from two locations and merges them
 (project overrides global):
 
-- **Global**: `~/.deepagents/config.toml` (shared with the upstream
-  `deepagents` CLI)
-- **Project**: `deepagents.toml` in the current directory or any ancestor
+- **Global**: `~/.langstage/config.toml`
+- **Project**: `langstage.toml` in the current directory or any ancestor
+
+Legacy locations (`~/.deepagents/config.toml`, `deepagents.toml`) are still
+read as fallbacks; move your config when convenient — `~/.deepagents/` now
+belongs to LangChain's `dcode`.
 
 Precedence: CLI args > env vars > project TOML > global TOML > defaults.
 
-Example `deepagents.toml`:
+Example `langstage.toml`:
 
 ```toml
 [agent]
@@ -133,7 +138,7 @@ thread_id = "my-thread"
 ## CLI Options
 
 ```
-Usage: deepagent-code [OPTIONS] [MESSAGE]
+Usage: langstage-cli [OPTIONS] [MESSAGE]
 
 Arguments:
   MESSAGE  Optional input to send to the agent immediately
@@ -166,13 +171,13 @@ agent = create_deep_agent(
 
 Then run it:
 ```bash
-deepagent-code -a my_agent.py:agent
+langstage-cli -a my_agent.py:agent
 ```
 
 ## Programmatic Use
 
 ```python
-from deepagent_code import stream_graph_updates, prepare_agent_input
+from langstage_cli import stream_graph_updates, prepare_agent_input
 
 input_data = prepare_agent_input(message="Hello!")
 

--- a/deepagent_code/__init__.py
+++ b/deepagent_code/__init__.py
@@ -1,27 +1,23 @@
-"""
-deepagent_code - A Claude Code-style CLI for running LangGraph agents.
+"""Deprecated alias package: ``deepagent_code`` is now ``langstage_cli``.
 
-The streaming / interrupt utilities that used to live here now come from
-``langgraph-stream-parser``. This package re-exports its dict-based convenience
-API for backward compatibility; the lower-level helpers (interrupt parsing,
-tool-call serialization, content extraction) are available from
-``langgraph_stream_parser.extractors`` if needed directly.
+Kept for one transition window so existing imports keep working. Import
+``langstage_cli`` instead.
 """
 
-from langgraph_stream_parser import (
-    prepare_agent_input,
-    stream_graph_updates,
-    resume_graph_from_interrupt,
-    astream_graph_updates,
-    aresume_graph_from_interrupt,
+import sys as _sys
+import warnings as _warnings
+
+import langstage_cli as _new
+from langstage_cli import *  # noqa: F401,F403
+from langstage_cli import cli, config  # noqa: F401
+
+_warnings.warn(
+    "deepagent_code has been renamed to langstage_cli; "
+    "this alias package will be removed in a future release.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
-__version__ = "0.2.0"
-
-__all__ = [
-    "prepare_agent_input",
-    "stream_graph_updates",
-    "resume_graph_from_interrupt",
-    "astream_graph_updates",
-    "aresume_graph_from_interrupt",
-]
+_sys.modules[__name__ + ".cli"] = cli
+_sys.modules[__name__ + ".config"] = config
+__version__ = getattr(_new, "__version__", "0")

--- a/langstage_cli/__init__.py
+++ b/langstage_cli/__init__.py
@@ -1,0 +1,27 @@
+"""
+langstage_cli - A Claude Code-style CLI for running LangGraph agents.
+
+The streaming / interrupt utilities that used to live here now come from
+``langgraph-stream-parser``. This package re-exports its dict-based convenience
+API for backward compatibility; the lower-level helpers (interrupt parsing,
+tool-call serialization, content extraction) are available from
+``langgraph_stream_parser.extractors`` if needed directly.
+"""
+
+from langgraph_stream_parser import (
+    prepare_agent_input,
+    stream_graph_updates,
+    resume_graph_from_interrupt,
+    astream_graph_updates,
+    aresume_graph_from_interrupt,
+)
+
+__version__ = "0.4.0"
+
+__all__ = [
+    "prepare_agent_input",
+    "stream_graph_updates",
+    "resume_graph_from_interrupt",
+    "astream_graph_updates",
+    "aresume_graph_from_interrupt",
+]

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -23,7 +23,7 @@ from langgraph_stream_parser import (
     astream_graph_updates,
     load_agent_spec,
 )
-from deepagent_code import config as config_module
+from langstage_cli import config as config_module
 
 # Platform-specific imports for keyboard input
 IS_WINDOWS = sys.platform == "win32"
@@ -906,7 +906,7 @@ def cmd_clear(args: str, context: Dict[str, Any]) -> Optional[str]:
 )
 def cmd_version(args: str, context: Dict[str, Any]) -> Optional[str]:
     """Display version information."""
-    print(f"\n{BOLD}{BRIGHT_CYAN}deepagent-code{RESET} v{__version__}")
+    print(f"\n{BOLD}{BRIGHT_CYAN}langstage-cli{RESET} v{__version__}")
     agent_name = context.get("agent_name", "Unknown")
     print(f"{DIM}Agent: {agent_name}{RESET}\n")
     return None
@@ -962,7 +962,7 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
 
         # Full resolved view: each value, where it came from, and the env var
         # / TOML key that sets it.
-        from deepagent_code.config import CodeConfig
+        from langstage_cli.config import CodeConfig
 
         for line in CodeConfig.resolve().describe().splitlines():
             print(f"  {line}")
@@ -1390,12 +1390,12 @@ def main(
 
     \b
     Examples:
-        deepagent-code "Hello, agent!"
-        deepagent-code -a my_agent.py "What can you do?"
-        deepagent-code -a my_agent.py:graph
-        deepagent-code -f ./prompt.md
-        deepagent-code --demo "try it with no API key"
-        deepagent-code --show-config
+        langstage-cli "Hello, agent!"
+        langstage-cli -a my_agent.py "What can you do?"
+        langstage-cli -a my_agent.py:graph
+        langstage-cli -f ./prompt.md
+        langstage-cli --demo "try it with no API key"
+        langstage-cli --show-config
     """
     if show_config:
         print(config_module.CodeConfig.resolve(toml_start=Path.cwd()).describe())
@@ -1465,8 +1465,8 @@ def main(
             else:
                 print(f"{RED}⏺ Error: No agent specified.{RESET}")
                 print(f"\n{DIM}Usage:{RESET}")
-                print("  deepagent-code path/to/agent.py:graph")
-                print("  deepagent-code mypackage.module:agent")
+                print("  langstage-cli path/to/agent.py:graph")
+                print("  langstage-cli mypackage.module:agent")
                 print(f"\n{DIM}Or set DEEPAGENT_AGENT_SPEC environment variable{RESET}")
                 sys.exit(1)
 

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -1,11 +1,11 @@
-"""Configuration for deepagent-code.
+"""Configuration for langstage-cli.
 
 Shares the TOML loader and the ``DEEPAGENT_*`` schema with the rest of the
 deep-agent family via ``langgraph_stream_parser.host``: global
 ``~/.deepagents/config.toml`` + project ``deepagents.toml`` (merged), then env
 vars, then CLI overrides.
 
-``CodeConfig`` is deepagent-code's view of that shared config. ``load_config`` /
+``CodeConfig`` is langstage-cli's view of that shared config. ``load_config`` /
 ``get`` / ``resolve`` remain for the ``[configurable]`` passthrough and ad-hoc
 lookups.
 """
@@ -77,12 +77,13 @@ def resolve(
 
 @dataclass
 class CodeConfig(HostConfig):
-    """deepagent-code's view of the shared config.
+    """langstage-cli's view of the shared config.
 
     Adds the CLI-specific keys on top of ``HostConfig``'s shared ones, resolved
-    through the same ``defaults < deepagents.toml < DEEPAGENT_* env <
-    overrides`` chain. ``DEEPAGENT_AGENT_SPEC`` is canonical;
-    ``DEEPAGENT_SPEC`` is a deprecated alias.
+    through the same ``defaults < langstage.toml < LANGSTAGE_* env <
+    overrides`` chain. The legacy ``deepagents.toml`` / ``DEEPAGENT_*``
+    vocabulary still resolves as a deprecated fallback (handled by the shared
+    resolver); the even-older ``DEEPAGENT_SPEC`` alias is reconciled below.
     """
 
     stream_mode: str = "updates"
@@ -91,7 +92,7 @@ class CodeConfig(HostConfig):
     async_mode: bool = False
 
     _ENV: ClassVar[dict] = {
-        "stream_mode": ("DEEPAGENT_STREAM_MODE", str),
+        "stream_mode": ("LANGSTAGE_STREAM_MODE", str),
     }
     _TOML: ClassVar[dict] = {
         "stream_mode": "ui.stream_mode",
@@ -103,11 +104,17 @@ class CodeConfig(HostConfig):
     @classmethod
     def resolve(cls, *, env: Optional[dict] = None, **kwargs: Any) -> "CodeConfig":
         env = dict(os.environ if env is None else env)
-        # Reconcile the legacy spec var — DEEPAGENT_AGENT_SPEC is canonical.
-        if not env.get("DEEPAGENT_AGENT_SPEC") and env.get("DEEPAGENT_SPEC"):
+        # Reconcile the oldest legacy spec var. DEEPAGENT_AGENT_SPEC itself is
+        # the shared resolver's legacy twin of LANGSTAGE_AGENT_SPEC, so mapping
+        # onto it keeps the full precedence chain intact.
+        if (
+            not env.get("LANGSTAGE_AGENT_SPEC")
+            and not env.get("DEEPAGENT_AGENT_SPEC")
+            and env.get("DEEPAGENT_SPEC")
+        ):
             env["DEEPAGENT_AGENT_SPEC"] = env["DEEPAGENT_SPEC"]
             warnings.warn(
-                "DEEPAGENT_SPEC is deprecated; use DEEPAGENT_AGENT_SPEC.",
+                "DEEPAGENT_SPEC is deprecated; use LANGSTAGE_AGENT_SPEC.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,16 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "deepagent-code"
-version = "0.3.0"
-description = "A Claude Code-style CLI for running LangGraph agents from the terminal"
+name = "langstage-cli"
+version = "0.4.0"
+description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [
     {name = "Kedar Dabhadkar", email = "kdabhadk@gmail.com"}
 ]
-keywords = ["langgraph", "cli", "agents", "llm", "ai", "claude-code"]
+keywords = ["langgraph", "langchain", "langstage", "cli", "agents", "llm", "ai"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "langgraph>=0.2.0",
-    "langgraph-stream-parser>=0.2.2,<0.3",
+    "langgraph-stream-parser>=0.3,<0.4",
     "click>=8.0.0",
     "python-dotenv",
     "deepagents",
@@ -41,16 +41,18 @@ dev = [
 ]
 
 [project.scripts]
-deepagent-code = "deepagent_code.cli:main"
+langstage-cli = "langstage_cli.cli:main"
+# Deprecated alias command — kept for one transition window.
+deepagent-code = "langstage_cli.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/dkedar7/deepagent-code"
-Repository = "https://github.com/dkedar7/deepagent-code"
-Issues = "https://github.com/dkedar7/deepagent-code/issues"
+Homepage = "https://github.com/dkedar7/langstage-cli"
+Repository = "https://github.com/dkedar7/langstage-cli"
+Issues = "https://github.com/dkedar7/langstage-cli/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["deepagent_code*"]
+include = ["langstage_cli*", "deepagent_code*"]
 
 [tool.black]
 line-length = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for deepagent-code."""
+"""Tests for langstage-cli."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@
 import pytest
 from click.testing import CliRunner
 
-from deepagent_code.cli import main, parse_agent_spec
+from langstage_cli.cli import main, parse_agent_spec
 
 
 class TestCliFlags:

--- a/tests/test_codeconfig.py
+++ b/tests/test_codeconfig.py
@@ -1,10 +1,10 @@
-"""Tests for CodeConfig — deepagent-code's HostConfig subclass."""
+"""Tests for CodeConfig — langstage-cli's HostConfig subclass."""
 
 from pathlib import Path
 
 import pytest
 
-from deepagent_code.config import CodeConfig
+from langstage_cli.config import CodeConfig
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for deepagent_code.config."""
+"""Tests for langstage_cli.config."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from deepagent_code import config
+from langstage_cli import config
 
 
 def _write(path: Path, content: str) -> None:

--- a/tests/test_rename_shim.py
+++ b/tests/test_rename_shim.py
@@ -1,0 +1,32 @@
+"""The deepagent_code → langstage_cli rename ships a deprecated alias package."""
+
+import sys
+
+import pytest
+
+
+def test_legacy_import_works_and_warns():
+    sys.modules.pop("deepagent_code", None)
+    sys.modules.pop("deepagent_code.cli", None)
+    sys.modules.pop("deepagent_code.config", None)
+    with pytest.warns(DeprecationWarning, match="langstage_cli"):
+        import deepagent_code  # noqa: F401
+
+
+def test_legacy_submodules_alias_the_new_ones():
+    import deepagent_code.config as old_config
+    import langstage_cli.config as new_config
+
+    assert old_config is new_config
+
+    import deepagent_code.cli as old_cli
+    import langstage_cli.cli as new_cli
+
+    assert old_cli is new_cli
+
+
+def test_legacy_package_reexports_public_api():
+    import deepagent_code
+
+    assert callable(deepagent_code.prepare_agent_input)
+    assert deepagent_code.__version__ == "0.4.0"


### PR DESCRIPTION
## What

**deepagent-code → langstage-cli (v0.4.0)** — the terminal stage of the LangStage family, repositioned as the generic terminal runner for *any* LangGraph `CompiledGraph` (dcode owns the batteries-included coding-agent niche; this runs *your* agent).

- Distribution `langstage-cli`; module `langstage_cli`. A deprecated alias package keeps `import deepagent_code` (+ `.cli`/`.config` submodules) working with a `DeprecationWarning`; the `deepagent-code` console command remains as an alias of `langstage-cli`.
- Canonical `LANGSTAGE_*` / `langstage.toml` vocabulary via parser `>=0.3,<0.4` (legacy `DEEPAGENT_*` / `deepagents.toml` still resolves — pinned by existing tests, which deliberately keep their legacy fixtures).
- README rewritten: new positioning line, rename notice, LangStage family table, `~/.langstage/` config docs.

## Tests

3 new shim tests (legacy import warns, submodule aliasing, public API re-export). Suite: 31 passed. Both `langstage-cli --demo` and `deepagent-code --demo` verified keyless locally. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
