### PR TITLE
Adopt AG-UI: widen parser ceiling + [agui] extra (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-06-14
+
+Adopt AG-UI: widen the langgraph-stream-parser ceiling to <0.5 and add an [agui] extra so this surface's agent can be served over AG-UI via langstage-agui. Additive; no runtime changes.
+
 ## [0.4.0] - 2026-06-10
 
 **deepagent-code is now `langstage-cli`** — the terminal stage of the LangStage family ("every stage for your LangGraph agent"). Repositioned as the generic terminal runner for *any* LangGraph `CompiledGraph` (LangChain's `dcode` owns the batteries-included coding-agent niche; this tool runs *your* agent).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ langstage-cli is the terminal stage of the **LangStage family**: write your agen
 
 📖 **Full documentation:** <https://dkedar7.github.io/langstage-docs/>
 
+### Serve over AG-UI
+
+This surface's agent — any LangGraph `CompiledGraph` — can also be served over the [AG-UI protocol](https://github.com/dkedar7/langgraph-stream-parser):
+
+```bash
+pip install "langgraph-stream-parser[agui]"
+langstage-agui --agent my_agent.py:graph
+```
+
 ## Installation
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "langgraph>=0.2.0",
-    "langgraph-stream-parser>=0.3,<0.4",
+    "langgraph-stream-parser>=0.3,<0.5",
     "click>=8.0.0",
     "python-dotenv",
     "deepagents",
@@ -39,6 +39,7 @@ dev = [
     "ruff==0.15.15",
     "mypy>=1.0.0",
 ]
+agui = ["langgraph-stream-parser[agui]>=0.4,<0.5"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"


### PR DESCRIPTION
Additive, low-risk AG-UI adoption for the langstage-cli terminal surface. Widens the langgraph-stream-parser ceiling to <0.5 and adds an [agui] optional extra (langgraph-stream-parser[agui]>=0.4,<0.5) so this surface's agent — any LangGraph CompiledGraph — can be served over the AG-UI protocol via langstage-agui. Bumps version to 0.5.0 with README and CHANGELOG notes. No runtime behavior changes; all 31 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)