### PR TITLE
ci: add minimal-install guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,24 @@ jobs:
 
       - name: Test
         run: pytest -ra
+
+  minimal-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install with NO extras (declared deps only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Import + CLI smoke on a minimal install
+        run: |
+          python -c "import langstage_cli; print('ok')"
+          langstage-cli --help
+          deepagent-code --help


### PR DESCRIPTION
Adds the family minimal-install CI guard (`pip install .`, no extras, import + CLI smoke). Verified clean on a fresh venv — no undeclared deps. CI-only, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)