### PR TITLE
fix: deepagents is dev-only, move out of runtime deps (0.5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,24 @@ jobs:
 
       - name: Test
         run: pytest -ra
+
+  minimal-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install with NO extras (declared deps only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Import + CLI smoke on a minimal install
+        run: |
+          python -c "import langstage_cli; print('ok')"
+          langstage-cli --help
+          deepagent-code --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.1 - 2026-06-16
+
+### Changed
+- Moved `deepagents` from runtime dependencies to the `[dev]` extra. Only the
+  bundled `examples/agent.py` (a dev sample, not shipped) imports it; the CLI never
+  does. A plain `pip install langstage-cli` no longer pulls deepagents/langchain/langgraph.
+
+
 All notable changes to this project will be documented in this file.
 
 ## [0.5.0] - 2026-06-14

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import uuid
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -57,8 +58,6 @@ SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇",
 
 
 # Version info — read from package metadata so it never drifts from pyproject.
-from importlib.metadata import version as _pkg_version, PackageNotFoundError
-
 try:
     __version__ = _pkg_version("langstage-cli")
 except PackageNotFoundError:  # pragma: no cover - editable/source checkout

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -56,8 +56,13 @@ BRIGHT_GREEN, BRIGHT_YELLOW = "\033[92m", "\033[93m"
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 
-# Version info
-__version__ = "0.2.0"
+# Version info — read from package metadata so it never drifts from pyproject.
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
+try:
+    __version__ = _pkg_version("langstage-cli")
+except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+    __version__ = "0.0.0+local"
 
 
 # Slash command registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -28,7 +28,6 @@ dependencies = [
     "langgraph-stream-parser>=0.3,<0.5",
     "click>=8.0.0",
     "python-dotenv",
-    "deepagents",
 ]
 
 [project.optional-dependencies]
@@ -38,6 +37,11 @@ dev = [
     "black>=23.0.0",
     "ruff==0.15.15",
     "mypy>=1.0.0",
+    # Only the bundled `examples/agent.py` (a dev sample, not shipped in the
+    # wheel) uses deepagents — the CLI itself never imports it. Keep it here so
+    # the example/tests run, but don't make every `pip install langstage-cli`
+    # pull deepagents + langchain + langgraph.
+    "deepagents>=0.3",
 ]
 agui = ["langgraph-stream-parser[agui]>=0.4,<0.5"]
 


### PR DESCRIPTION
Only the bundled `examples/agent.py` (a dev sample, **not shipped** in the wheel) uses `deepagents`; the CLI itself never imports it. Moved to the `[dev]` extra so a plain `pip install langstage-cli` no longer drags in deepagents + langchain + langgraph. The new minimal-install guard (no extras) confirms the CLI imports + runs without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)