### PR TITLE
fix: --show-config reflects CLI flags (Closes #20) (0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.2 - 2026-06-17
+
+### Fixed
+- `--show-config` now reflects CLI flags (#20). It resolved config WITHOUT the CLI
+  overrides, so `-a/--agent`, `-v/--verbose`, `--stream-mode`, etc. showed as
+  `[default]` and the reported `[source]` could contradict the real run (e.g. a
+  CLI flag set alongside an env var was reported as won by the env, but the run
+  used the flag). The same override dict now feeds both `--show-config` and the
+  actual run, so the diagnostic matches reality — CLI-set values show as `[override]`.
+
+
 ## 0.5.1 - 2026-06-16
 
 ### Changed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1401,16 +1401,35 @@ def main(
         langstage-cli --demo "try it with no API key"
         langstage-cli --show-config
     """
-    if show_config:
-        print(config_module.CodeConfig.resolve(toml_start=Path.cwd()).describe())
-        return
-
     if demo:
         if agent_spec:
             print(f"{RED}⏺ Error: --demo and -a/--agent are mutually exclusive{RESET}")
             sys.exit(1)
         # The keyless echo agent shipped with the shared core.
         agent_spec = "langgraph_stream_parser.demo.stub:graph"
+
+    # CLI flags are the highest-precedence config layer. Build the override dict
+    # ONCE and use it for both --show-config and the real run, so the diagnostic
+    # reflects exactly what a run resolves (CLI-set values then show as
+    # `[override]`, not `[default]`). Resolving --show-config without these was
+    # the bug in #20.
+    cli_overrides = {
+        "agent_spec": agent_spec,
+        "graph_name": graph_name,
+        "stream_mode": stream_mode,
+        # bool flags only override when actually passed; otherwise fall back to
+        # TOML/env/default.
+        "async_mode": True if use_async else None,
+        "verbose": True if verbose else None,
+    }
+
+    if show_config:
+        print(
+            config_module.CodeConfig.resolve(
+                toml_start=Path.cwd(), overrides=cli_overrides
+            ).describe()
+        )
+        return
 
     try:
         # Handle -f/--file option: read message from file
@@ -1441,15 +1460,7 @@ def main(
         # (DEEPAGENT_AGENT_SPEC is canonical; DEEPAGENT_SPEC is a deprecated alias.)
         cfg = config_module.CodeConfig.resolve(
             toml_start=Path.cwd(),
-            overrides={
-                "agent_spec": agent_spec,
-                "graph_name": graph_name,
-                "stream_mode": stream_mode,
-                # bool flags only override when actually passed; otherwise fall
-                # back to TOML/env/default.
-                "async_mode": True if use_async else None,
-                "verbose": True if verbose else None,
-            },
+            overrides=cli_overrides,
         )
         final_spec = cfg.agent_spec
         final_graph_name_default = cfg.graph_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.1"
+version = "0.5.2"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -4,6 +4,7 @@ Before the fix, the --show-config branch resolved config WITHOUT the CLI
 overrides, so flags showed as `[default]` and the reported source could
 contradict the real run.
 """
+
 import re
 
 from click.testing import CliRunner

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -1,0 +1,46 @@
+"""Regression tests for #20: `--show-config` must reflect CLI flags.
+
+Before the fix, the --show-config branch resolved config WITHOUT the CLI
+overrides, so flags showed as `[default]` and the reported source could
+contradict the real run.
+"""
+import re
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_show_config_reflects_cli_flags():
+    with CliRunner().isolated_filesystem():  # no stray toml
+        r = CliRunner().invoke(
+            main, ["-a", "fromcli.py:graph", "-v", "--stream-mode", "values", "--show-config"]
+        )
+    assert r.exit_code == 0, r.output
+    # CLI-set values appear with the [override] source, not [default].
+    assert re.search(r"agent_spec\s*=\s*fromcli\.py:graph\s*\[override\]", r.output), r.output
+    assert re.search(r"stream_mode\s*=\s*values\s*\[override\]", r.output), r.output
+    assert re.search(r"verbose\s*=\s*True\s*\[override\]", r.output), r.output
+
+
+def test_show_config_cli_flag_beats_env():
+    with CliRunner().isolated_filesystem():
+        r = CliRunner().invoke(
+            main,
+            ["-a", "fromcli.py:graph", "--show-config"],
+            env={"LANGSTAGE_AGENT_SPEC": "fromenv.py:graph"},
+        )
+    assert r.exit_code == 0, r.output
+    # the CLI flag wins (matches what a real run does), not the env var
+    assert re.search(r"agent_spec\s*=\s*fromcli\.py:graph\s*\[override\]", r.output), r.output
+    assert "fromenv.py:graph" not in r.output.split("agent_spec")[1].split("\n")[0]
+
+
+def test_show_config_without_flags_still_reports_env():
+    with CliRunner().isolated_filesystem():
+        r = CliRunner().invoke(
+            main, ["--show-config"], env={"LANGSTAGE_AGENT_SPEC": "fromenv.py:graph"}
+        )
+    assert r.exit_code == 0, r.output
+    # no flags → env is correctly the winning source (no regression)
+    assert re.search(r"agent_spec\s*=\s*fromenv\.py:graph\s*\[env:", r.output), r.output


### PR DESCRIPTION
Fixes the routine-filed bug #20. `--show-config` resolved config **without** the CLI overrides, so `-a`/`-v`/`--stream-mode`/etc. showed as `[default]` and the reported `[source]` could contradict the real run (CLI-flag-vs-env reported the wrong winner).

**Fix:** build the override dict once, feed it to both the `--show-config` resolve and the run resolve — the diagnostic now matches reality (CLI-set values show `[override]`). `--demo` handling moved before the branch so it's reflected too.

Verified against all three scenarios from the report; +3 regression tests (`tests/test_show_config.py`); suite 34 passed.

Follow-up (not in this PR): the interactive REPL `/config` (`cmd_config`) has the same root cause but needs the CLI overrides threaded into its `context` — lower priority, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)