### PR TITLE
fix: canonical LANGSTAGE_* names in --help + add --version (Closes #22) (0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.3 - 2026-06-17
+
+### Fixed
+- `--help` and runtime hints now lead with the canonical `LANGSTAGE_*` env vars and
+  `langstage.toml` (the legacy `DEEPAGENT_*` / `deepagents.toml` are noted only as
+  deprecated aliases), matching the README and `--show-config` output. Previously the
+  CLI's own help advertised the deprecated names as canonical and never mentioned
+  `LANGSTAGE_*` (#22).
+
+### Added
+- `--version` flag (reads the version from package metadata) — was missing (#22).
+
+
 ## 0.5.2 - 2026-06-17
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -998,7 +998,7 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
                 context["verbose"] = value.lower() in ("true", "1", "on", "yes")
                 print(f"{GREEN}✓ Set verbose = {context['verbose']}{RESET}")
             else:
-                print(f"{YELLOW}Cannot modify {key} at runtime (edit deepagents.toml){RESET}")
+                print(f"{YELLOW}Cannot modify {key} at runtime (edit langstage.toml){RESET}")
     return None
 
 
@@ -1302,6 +1302,7 @@ def run_conversation_loop(
 
 
 @click.command()
+@click.version_option(__version__, "--version", prog_name="langstage-cli")
 @click.argument("message", required=False)
 @click.option(
     "--agent",
@@ -1354,7 +1355,7 @@ def run_conversation_loop(
     "show_config",
     is_flag=True,
     default=False,
-    help="Print the resolved configuration (defaults < deepagents.toml < env < CLI) and exit",
+    help="Print the resolved configuration (defaults < langstage.toml < env < CLI) and exit",
 )
 def main(
     message: Optional[str],
@@ -1380,17 +1381,18 @@ def main(
     - package.module            (Python module path)
     - package.module:agent      (module with graph variable name)
 
-    Supports environment variables for configuration:
+    Supports environment variables for configuration (legacy DEEPAGENT_*
+    names still work as deprecated aliases):
 
     \b
-    - DEEPAGENT_AGENT_SPEC: Agent location (same formats as above).
-      (DEEPAGENT_SPEC is still accepted as a deprecated alias.)
-    - DEEPAGENT_WORKSPACE_ROOT: Working directory for the agent
-    - DEEPAGENT_STREAM_MODE: Stream mode for LangGraph (updates or values)
+    - LANGSTAGE_AGENT_SPEC: Agent location (same formats as above).
+    - LANGSTAGE_WORKSPACE_ROOT: Working directory for the agent
+    - LANGSTAGE_STREAM_MODE: Stream mode for LangGraph (updates or values)
 
-    Reads ~/.deepagents/config.toml (global) and deepagents.toml (project,
+    Reads ~/.langstage/config.toml (global) and langstage.toml (project,
     walks up from cwd). Precedence: CLI args > env vars > project TOML >
-    global TOML > built-in defaults.
+    global TOML > built-in defaults. (The legacy ~/.deepagents/config.toml and
+    deepagents.toml are still read as deprecated fallbacks.)
 
     \b
     Examples:
@@ -1482,7 +1484,7 @@ def main(
                 print(f"\n{DIM}Usage:{RESET}")
                 print("  langstage-cli path/to/agent.py:graph")
                 print("  langstage-cli mypackage.module:agent")
-                print(f"\n{DIM}Or set DEEPAGENT_AGENT_SPEC environment variable{RESET}")
+                print(f"\n{DIM}Or set the LANGSTAGE_AGENT_SPEC environment variable{RESET}")
                 sys.exit(1)
 
         # Change to workspace root if specified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.2"
+version = "0.5.3"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,27 @@
+"""Regression tests for #22: user-facing strings use the canonical LANGSTAGE_*
+names, and a `--version` flag exists.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_version_flag_exists():
+    r = CliRunner().invoke(main, ["--version"])
+    assert r.exit_code == 0, r.output
+    assert "langstage-cli" in r.output
+    assert "0.0.0" not in r.output  # reports the real version, not the fallback
+
+
+def test_help_leads_with_canonical_names():
+    r = CliRunner().invoke(main, ["--help"])
+    assert r.exit_code == 0, r.output
+    out = r.output
+    # canonical LANGSTAGE_* / langstage.toml are present...
+    assert "LANGSTAGE_AGENT_SPEC" in out
+    assert "LANGSTAGE_WORKSPACE_ROOT" in out
+    assert "LANGSTAGE_STREAM_MODE" in out
+    assert "langstage.toml" in out
+    # ...and the legacy names are no longer presented as the only config vocab
+    assert "DEEPAGENT_AGENT_SPEC" not in out


### PR DESCRIPTION
Fixes routine-filed #22. The CLI's `--help`, `--show-config` help, and two runtime hints advertised the **deprecated** `DEEPAGENT_*`/`deepagents.toml` names as canonical and never mentioned `LANGSTAGE_*` — contradicting the README + `--show-config`. Now they lead with `LANGSTAGE_*`/`langstage.toml` (legacy noted as deprecated aliases).

Also adds the missing **`--version`** flag (the secondary nit in #22) — reads the version from package metadata.

+2 regression tests; suite 36 passed; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)