### PR TITLE
fix: derive langstage_cli.__version__ from metadata (was stale 0.4.0) (0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.4 - 2026-06-19
+
+### Fixed
+- `langstage_cli.__version__` was a hard-coded `"0.4.0"` and had drifted (the
+  package was at 0.5.3). It now derives from the installed distribution metadata
+  (`importlib.metadata.version`), so it always matches `pyproject.toml` and can't
+  drift again. (The `--version` flag already read metadata; this aligns the
+  exported module attribute.)
+
 ## 0.5.3 - 2026-06-17
 
 ### Fixed

--- a/langstage_cli/__init__.py
+++ b/langstage_cli/__init__.py
@@ -8,6 +8,8 @@ tool-call serialization, content extraction) are available from
 ``langgraph_stream_parser.extractors`` if needed directly.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from langgraph_stream_parser import (
     prepare_agent_input,
     stream_graph_updates,
@@ -16,7 +18,12 @@ from langgraph_stream_parser import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.4.0"
+# Single source of truth is the installed distribution metadata, so this can
+# never drift from pyproject's version (it was stuck at a stale "0.4.0").
+try:
+    __version__ = version("langstage-cli")
+except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+    __version__ = "0.0.0+local"
 
 __all__ = [
     "prepare_agent_input",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.3"
+version = "0.5.4"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rename_shim.py
+++ b/tests/test_rename_shim.py
@@ -27,6 +27,9 @@ def test_legacy_submodules_alias_the_new_ones():
 
 def test_legacy_package_reexports_public_api():
     import deepagent_code
+    import langstage_cli
 
     assert callable(deepagent_code.prepare_agent_input)
-    assert deepagent_code.__version__ == "0.4.0"
+    # The shim mirrors the new package's version (now derived from metadata),
+    # so assert equality rather than a hard-coded literal that would drift.
+    assert deepagent_code.__version__ == langstage_cli.__version__


### PR DESCRIPTION
The exported `langstage_cli.__version__` was a hard-coded `"0.4.0"` while the package had advanced to **0.5.3** — a silently-wrong public attribute. (The `--version` CLI flag already read metadata; this aligns the module attribute.)

Same drift the daily routine filed for langstage-vscode (#9). Fix: derive from installed metadata, matching `cli.py`'s `--version` and the langstage/hermes packages, so it can't drift again.

- `langstage_cli/__init__.py`: `__version__` now `importlib.metadata.version("langstage-cli")` with a `0.0.0+local` fallback.
- `tests/test_rename_shim.py`: assert `deepagent_code.__version__ == langstage_cli.__version__` (dynamic) instead of a hard-coded literal that would re-drift.
- Bumped to **0.5.4** + CHANGELOG.

36 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)