### PR TITLE
fix: UTF-8 stdio so langstage-cli --demo works on Windows cp1252 (0.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.5 - 2026-06-20
+
+### Fixed
+- **Headline `langstage-cli --demo "hello"` crashed on a default Windows console
+  (cp1252) with `UnicodeEncodeError`** — the spinner's Braille frames and the
+  `✓`/`⏺` status glyphs couldn't encode. `main()` now reconfigures stdio to UTF-8
+  (`errors="replace"`) at entry, and the spinner thread can no longer crash the
+  process on a print error.
+- **`--help` showed a mojibake character** where an em-dash was in the `--demo`
+  option text; replaced with plain ASCII so help renders on any console.
+- **README `langstage.toml` example documented `[agent] workspace_root`**, which
+  is silently ignored — the real key is `[workspace] root`. Corrected.
+
 ## 0.5.4 - 2026-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Example `langstage.toml`:
 ```toml
 [agent]
 spec = "my_agent.py:graph"
-workspace_root = "."
+
+[workspace]
+root = "."
 
 [ui]
 verbose = true

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -190,11 +190,15 @@ class Spinner:
             frame = SPINNER_FRAMES[self.frame_idx % len(SPINNER_FRAMES)]
             elapsed = time.time() - self.start_time
             elapsed_str = f"{int(elapsed)}s"
-            print(
-                f"\r{CYAN}{frame}{RESET} {DIM}{self.message}... {elapsed_str}{RESET}",
-                end="",
-                flush=True,
-            )
+            # Never let a stdout hiccup in this daemon thread crash the run.
+            try:
+                print(
+                    f"\r{CYAN}{frame}{RESET} {DIM}{self.message}... {elapsed_str}{RESET}",
+                    end="",
+                    flush=True,
+                )
+            except (UnicodeEncodeError, ValueError):
+                pass
             self.frame_idx += 1
             time.sleep(0.08)
 
@@ -1348,7 +1352,7 @@ def run_conversation_loop(
     "--demo",
     is_flag=True,
     default=False,
-    help="Run with the built-in keyless demo agent — no API key needed",
+    help="Run with the built-in keyless demo agent (no API key needed)",
 )
 @click.option(
     "--show-config",
@@ -1403,6 +1407,16 @@ def main(
         langstage-cli --demo "try it with no API key"
         langstage-cli --show-config
     """
+    # Windows consoles default to cp1252, where the spinner (Braille frames) and
+    # status glyphs (✓ ⏺ —) raise UnicodeEncodeError — the documented
+    # `langstage-cli --demo "hello"` one-liner crashed before any output. Force
+    # UTF-8 with errors="replace" so a glyph can never crash the process.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):  # non-reconfigurable stream
+            pass
+
     if demo:
         if agent_spec:
             print(f"{RED}⏺ Error: --demo and -a/--agent are mutually exclusive{RESET}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.4"
+version = "0.5.5"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_unicode_console.py
+++ b/tests/test_unicode_console.py
@@ -1,0 +1,31 @@
+"""Regression: the headline `langstage-cli --demo` must not crash on a non-UTF-8
+console (Windows cp1252).
+
+The spinner (Braille frames) and status glyphs (✓ ⏺) raised UnicodeEncodeError on
+a default Windows console, so the documented one-liner crashed before output.
+`main()` now reconfigures stdio to UTF-8 (errors="replace"). We force `cp1252`
+via PYTHONIOENCODING so this reproduces on any platform — without the fix this
+test exits non-zero with a UnicodeEncodeError traceback.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def test_demo_runs_on_cp1252_console():
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    env.pop("PYTHONUTF8", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", "from langstage_cli.cli import main; main()", "--demo", "hello"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    assert "UnicodeEncodeError" not in proc.stderr, proc.stderr
+    # The demo stub echoes the input back.
+    assert "demo agent" in proc.stdout.lower() or "hello" in proc.stdout.lower(), proc.stdout


### PR DESCRIPTION
Cluster 5 (Windows Unicode) from the comprehensive dogfood run.

## Major — headline command crashed on Windows
`langstage-cli --demo "hello"` (README's first Quickstart line) crashed with `UnicodeEncodeError` on a default Windows console (cp1252): the spinner's Braille frames (`⠋…`) and the `✓`/`⏺` status glyphs can't encode in cp1252, so it died before producing usable output.

- `main()` now reconfigures `sys.stdout`/`sys.stderr` to UTF-8 (`errors="replace"`) at entry, so glyphs render (or degrade) instead of crashing.
- The spinner daemon thread guards its `print` so a stdout hiccup can never take down the run.

## Minors
- `--help` showed a mojibake character where an em-dash belonged in the `--demo` option text → plain ASCII (`--help` is printed by Click before `main()` runs, so it's fixed at the source string).
- README's `langstage.toml` example documented `[agent] workspace_root`, which is **silently ignored** — the real key is `[workspace] root` (verified: `workspace.root` resolves; `agent.workspace_root` doesn't). Corrected.

## Test
`tests/test_unicode_console.py` forces `PYTHONIOENCODING=cp1252` and runs `--demo` in a subprocess — reproduces the crash on any platform (incl. Linux CI) without the fix. **37 passed**; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)