### PR TITLE
fix: --stream-mode values no longer fatal-crashes; render dict messages (0.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.6 - 2026-06-21
+
+### Fixed
+- **`--stream-mode values` crashed with a fatal Python error** instead of working
+  or erroring cleanly. `values` was advertised (README / `--help` / `--show-config`)
+  but the render path only supports `updates`/`messages`; the resulting `ValueError`
+  surfaced while the spinner **daemon thread** held stdout, producing
+  `Fatal Python error: _enter_buffered_busy ... at interpreter shutdown` (exit 127).
+  Now: `--stream-mode` is a `Choice {updates, messages}` (clean rejection of the
+  flag), the resolved value (incl. `LANGSTAGE_STREAM_MODE`, which bypasses the flag)
+  is validated up front with a readable error, and the stream loop always stops the
+  spinner via `try/finally` so no streaming error can crash the interpreter. README /
+  `--help` / docstring no longer list `values`.
+- **Dict-form messages now render** — a `CompiledGraph` returning
+  `{"role": "assistant", "content": ...}` produced no output. Fixed upstream in
+  `langgraph-stream-parser` 0.6.6; the core pin is modernized from the stale
+  `<0.5` to `>=0.6.6,<0.7` (base + `[agui]`) to deliver it.
+
 ## 0.5.5 - 2026-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ langstage-cli
 # Working directory
 export LANGSTAGE_WORKSPACE_ROOT="/path/to/workspace"
 
-# Stream mode (updates or values)
+# Stream mode (updates or messages)
 export LANGSTAGE_STREAM_MODE="updates"
 ```
 
@@ -162,7 +162,8 @@ Options:
   -f, --file PATH                 Read message from a file (any extension)
   --interactive/--no-interactive  Handle interrupts (default: interactive)
   --async-mode/--sync-mode        Async streaming (default: sync)
-  --stream-mode TEXT              Stream mode (updates or values)
+  --stream-mode [updates|messages]
+                                  Stream mode (default: updates)
   -v, --verbose                   Verbose output
 ```
 

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -755,25 +755,26 @@ async def run_single_turn_async(
         spinner = Spinner("Thinking")
         spinner.start()
 
-        async for chunk in astream_graph_updates(
-            graph, input_data, config=config, stream_mode=stream_mode
-        ):
-            # Stop spinner on first chunk
-            if first_chunk:
-                spinner.stop()
-                first_chunk = False
+        try:
+            async for chunk in astream_graph_updates(
+                graph, input_data, config=config, stream_mode=stream_mode
+            ):
+                # Stop spinner on first chunk
+                if first_chunk:
+                    spinner.stop()
+                    first_chunk = False
 
-            print_chunk(chunk, verbose=verbose)
+                print_chunk(chunk, verbose=verbose)
 
-            if chunk.get("status") == "interrupt":
-                has_interrupt = True
-                # Count pending action requests
-                interrupt_data = chunk.get("interrupt", {})
-                action_requests = interrupt_data.get("action_requests", [])
-                num_pending_actions = len(action_requests) if action_requests else 1
-
-        # Ensure spinner is stopped even if no chunks received
-        if first_chunk:
+                if chunk.get("status") == "interrupt":
+                    has_interrupt = True
+                    # Count pending action requests
+                    interrupt_data = chunk.get("interrupt", {})
+                    action_requests = interrupt_data.get("action_requests", [])
+                    num_pending_actions = len(action_requests) if action_requests else 1
+        finally:
+            # Always stop the spinner (see sync variant) so a streaming error
+            # can't leave a daemon thread holding stdout at interpreter shutdown.
             spinner.stop()
 
         if has_interrupt and interactive:
@@ -804,25 +805,27 @@ def run_single_turn_sync(
         spinner = Spinner("Thinking")
         spinner.start()
 
-        for chunk in stream_graph_updates(
-            graph, input_data, config=config, stream_mode=stream_mode
-        ):
-            # Stop spinner on first chunk
-            if first_chunk:
-                spinner.stop()
-                first_chunk = False
+        try:
+            for chunk in stream_graph_updates(
+                graph, input_data, config=config, stream_mode=stream_mode
+            ):
+                # Stop spinner on first chunk
+                if first_chunk:
+                    spinner.stop()
+                    first_chunk = False
 
-            print_chunk(chunk, verbose=verbose)
+                print_chunk(chunk, verbose=verbose)
 
-            if chunk.get("status") == "interrupt":
-                has_interrupt = True
-                # Count pending action requests
-                interrupt_data = chunk.get("interrupt", {})
-                action_requests = interrupt_data.get("action_requests", [])
-                num_pending_actions = len(action_requests) if action_requests else 1
-
-        # Ensure spinner is stopped even if no chunks received
-        if first_chunk:
+                if chunk.get("status") == "interrupt":
+                    has_interrupt = True
+                    # Count pending action requests
+                    interrupt_data = chunk.get("interrupt", {})
+                    action_requests = interrupt_data.get("action_requests", [])
+                    num_pending_actions = len(action_requests) if action_requests else 1
+        finally:
+            # Always stop the spinner — if the stream raises, an unstopped daemon
+            # spinner thread holds stdout at interpreter shutdown, which crashes
+            # with "Fatal Python error: _enter_buffered_busy".
             spinner.stop()
 
         if has_interrupt and interactive:
@@ -1339,7 +1342,8 @@ def run_conversation_loop(
 )
 @click.option(
     "--stream-mode",
-    help="Stream mode for LangGraph (default: 'updates')",
+    type=click.Choice(["updates", "messages"]),
+    help="Stream mode: 'updates' (default) or 'messages' (token-level).",
 )
 @click.option(
     "--verbose",
@@ -1391,7 +1395,7 @@ def main(
     \b
     - LANGSTAGE_AGENT_SPEC: Agent location (same formats as above).
     - LANGSTAGE_WORKSPACE_ROOT: Working directory for the agent
-    - LANGSTAGE_STREAM_MODE: Stream mode for LangGraph (updates or values)
+    - LANGSTAGE_STREAM_MODE: Stream mode for LangGraph (updates or messages)
 
     Reads ~/.langstage/config.toml (global) and langstage.toml (project,
     walks up from cwd). Precedence: CLI args > env vars > project TOML >
@@ -1481,6 +1485,15 @@ def main(
         final_spec = cfg.agent_spec
         final_graph_name_default = cfg.graph_name
         final_stream_mode = cfg.stream_mode
+        # The CLI's render path only supports 'updates' / 'messages'. Reject anything
+        # else (e.g. LANGSTAGE_STREAM_MODE=values, which bypasses the flag's Choice)
+        # with a clean error instead of a fatal crash deep in the stream worker.
+        if final_stream_mode not in ("updates", "messages"):
+            print(
+                f"{RED}⏺ Error: unsupported stream mode {final_stream_mode!r} "
+                f"(use 'updates' or 'messages'){RESET}"
+            )
+            sys.exit(2)
         use_async = cfg.async_mode
         verbose = cfg.verbose
         # Only change directory when a workspace root was actually configured.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.5"
+version = "0.5.6"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,7 +25,9 @@ classifiers = [
 
 dependencies = [
     "langgraph>=0.2.0",
-    "langgraph-stream-parser>=0.3,<0.5",
+    # >=0.6.6 modernizes off the stale <0.5 pin and carries the dict-form-message
+    # fix, so a CompiledGraph returning {"role":...,"content":...} renders (gh #-dogfood).
+    "langgraph-stream-parser>=0.6.6,<0.7",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -43,7 +45,7 @@ dev = [
     # pull deepagents + langchain + langgraph.
     "deepagents>=0.3",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.4,<0.5"]
+agui = ["langgraph-stream-parser[agui]>=0.6.6,<0.7"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -15,12 +15,12 @@ from langstage_cli.cli import main
 def test_show_config_reflects_cli_flags():
     with CliRunner().isolated_filesystem():  # no stray toml
         r = CliRunner().invoke(
-            main, ["-a", "fromcli.py:graph", "-v", "--stream-mode", "values", "--show-config"]
+            main, ["-a", "fromcli.py:graph", "-v", "--stream-mode", "messages", "--show-config"]
         )
     assert r.exit_code == 0, r.output
     # CLI-set values appear with the [override] source, not [default].
     assert re.search(r"agent_spec\s*=\s*fromcli\.py:graph\s*\[override\]", r.output), r.output
-    assert re.search(r"stream_mode\s*=\s*values\s*\[override\]", r.output), r.output
+    assert re.search(r"stream_mode\s*=\s*messages\s*\[override\]", r.output), r.output
     assert re.search(r"verbose\s*=\s*True\s*\[override\]", r.output), r.output
 
 

--- a/tests/test_stream_mode.py
+++ b/tests/test_stream_mode.py
@@ -1,0 +1,36 @@
+"""--stream-mode validation (gh #-dogfood).
+
+`values` was advertised but unsupported by the CLI's render path; passing it
+crashed with a fatal interpreter-shutdown error (a ValueError surfaced while the
+spinner daemon thread held stdout). Now: the flag is a Choice {updates,messages},
+and the resolved value (incl. LANGSTAGE_STREAM_MODE, which bypasses the flag) is
+validated up front with a clean error.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_stream_mode_values_flag_rejected_cleanly():
+    r = CliRunner().invoke(main, ["--demo", "--no-interactive", "--stream-mode", "values", "hi"])
+    assert r.exit_code != 0
+    assert "values" in r.output
+    assert "Fatal" not in r.output  # no interpreter-shutdown crash
+
+
+def test_stream_mode_messages_flag_accepted():
+    # A valid mode must still be accepted by the Choice (parses, doesn't error on the flag).
+    r = CliRunner().invoke(main, ["--stream-mode", "messages", "--show-config"])
+    assert r.exit_code == 0, r.output
+    assert "messages" in r.output
+
+
+def test_stream_mode_values_via_env_rejected():
+    r = CliRunner().invoke(
+        main,
+        ["--demo", "--no-interactive", "hi"],
+        env={"LANGSTAGE_STREAM_MODE": "values"},
+    )
+    assert r.exit_code == 2, r.output
+    assert "unsupported stream mode" in r.output.lower()


### PR DESCRIPTION
Two majors from the dogfood re-run.

## `--stream-mode values` → fatal Python crash
`values` is advertised (README / `--help` / `--show-config`) but the CLI render path only supports `updates`/`messages`. Passing it produced:
```
Fatal Python error: _enter_buffered_busy ... at interpreter shutdown, possibly due to daemon threads  (exit 127)
```
— the StreamParser's `ValueError` surfaced while the **spinner daemon thread** still held stdout. Fix:
- `--stream-mode` is now `Choice {updates, messages}` (clean rejection of the flag).
- The resolved value (incl. `LANGSTAGE_STREAM_MODE`, which bypasses the flag) is validated up front with a readable error (exit 2).
- The stream loop always stops the spinner via `try/finally`, so **no** streaming error can leave a daemon thread crashing the interpreter at shutdown.
- Dropped `values` from README / `--help` / docstring.

## Dict-form messages rendered nothing
A `CompiledGraph` returning `{"role":"assistant","content":...}` (which LangGraph's `add_messages` accepts) showed no output. Fixed in `langgraph-stream-parser` 0.6.6; **modernized the core pin from the stale `<0.5` to `>=0.6.6,<0.7`** (base + `[agui]`) to deliver it. Verified end-to-end: a dict-returning agent now renders through the CLI.

## Tests
`tests/test_stream_mode.py` (flag rejected cleanly, valid mode accepted, env-var path rejected). Updated `test_show_config` to a valid mode. **40 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)