### PR TITLE
fix: /help no longer leaks a literal "36m" / bleeds ANSI (0.5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.8 - 2026-06-22
+
+### Fixed
+- **`/help` leaked a literal `36m` and bled ANSI color.** The Commands block built
+  each command's alias list with `f", {CYAN}/{RESET}, {CYAN}/".join([""] + aliases)[4:]`,
+  whose `[4:]` slice cut into the leading `\x1b[36m` escape — printing stray `36m`
+  text and leaving color unterminated. Each alias is now rendered as its own clean
+  cyan `/token`. (gh #-dogfood)
+
 ## 0.5.7 - 2026-06-21
 
 ### Docs

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -847,7 +847,10 @@ def print_help():
     for cmd in sorted(commands, key=lambda c: c.name):
         aliases_str = ""
         if cmd.aliases:
-            aliases_str = f", {CYAN}/{RESET}, {CYAN}/".join([""] + cmd.aliases)[4:]
+            # Each alias as its own cyan "/x" token. The old
+            # `…join([""] + aliases)[4:]` sliced into the leading ANSI escape,
+            # leaking a literal "36m" and bleeding color (gh #-dogfood).
+            aliases_str = "".join(f", {CYAN}/{alias}{RESET}" for alias in cmd.aliases)
         print(f"  {CYAN}/{cmd.name}{RESET}{aliases_str}")
         print(f"    {DIM}{cmd.description}{RESET}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.7"
+version = "0.5.8"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_help_render.py
+++ b/tests/test_help_render.py
@@ -1,0 +1,35 @@
+"""`/help` must not leak ANSI fragments (gh #-dogfood).
+
+The Commands block built alias strings with `…join([""] + aliases)[4:]`, whose
+slice cut into the leading `\x1b[36m` escape — leaking a literal "36m" and bleeding
+color. Each alias is now its own cyan token.
+"""
+
+import io
+import re
+from contextlib import redirect_stdout
+
+from langstage_cli.cli import print_help
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _rendered_help() -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_help()
+    return buf.getvalue()
+
+
+def test_help_has_no_leaked_ansi_fragment():
+    plain = _ANSI.sub("", _rendered_help())
+    # No bare color-code residue once real escapes are stripped.
+    assert "36m" not in plain
+    assert "[0m" not in plain and "[36" not in plain
+
+
+def test_help_renders_aliases_cleanly():
+    plain = _ANSI.sub("", _rendered_help())
+    # A multi-alias command renders as comma-separated /tokens.
+    assert "/quit" in plain
+    assert re.search(r"/quit(, /\w+)+", plain), plain


### PR DESCRIPTION
Confirmed minor from the nightly routine.

`/help`'s Commands block built each command's alias list with:
```python
f", {CYAN}/{RESET}, {CYAN}/".join([""] + cmd.aliases)[4:]
```
The `[4:]` slice was meant to strip a leading separator but cut into the leading `\x1b[36m` escape, so `/help` printed a stray literal **`36m`** and left color **unterminated** (bleeding into later output).

Now each alias is rendered as its own clean cyan `/token`:
```
/quit, /q, /exit
```

Test (`test_help_render.py`) strips real ANSI and asserts no `36m`/code residue remains. **42 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)