### PR TITLE
fix: resolve relative agent spec before chdir into workspace root (0.5.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.10 - 2026-06-25
+
+### Fixed
+- **A relative `-a` / `LANGSTAGE_AGENT_SPEC` broke the moment `LANGSTAGE_WORKSPACE_ROOT`
+  was set.** The CLI `os.chdir()`s into the workspace root *before* loading the
+  agent, so a relative `my_agent.py:graph` was resolved against the workspace
+  root instead of the invocation cwd — failing with `Agent file not found` for a
+  file sitting right there in the current directory (both vars are documented
+  side-by-side, so setting both is expected usage). The file part of a relative
+  spec is now resolved to an absolute path *before* the chdir; module specs
+  (`pkg.mod:attr`) and absolute paths are unaffected. (Found by the dogfood
+  routine, gh #30.)
+
 ## 0.5.9 - 2026-06-22
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -493,6 +493,32 @@ def load_graph(spec: str, default_graph_name: str = "graph"):
     return graph, graph_name
 
 
+def _absolutize_file_spec(spec: str) -> str:
+    """Resolve a relative *file-path* agent spec to an absolute path against the
+    current cwd.
+
+    The CLI chdirs into ``LANGSTAGE_WORKSPACE_ROOT`` before loading the agent, so
+    a relative ``-a my_agent.py:graph`` would otherwise be looked up under the
+    workspace root instead of where the user actually invoked the command (and
+    put the file). Resolving the file part up front keeps the spec anchored to
+    the invocation cwd. Module specs (``pkg.mod:attr``) and already-absolute
+    paths pass through unchanged. (gh #30)
+    """
+    if not spec:
+        return spec
+    path_part, suffix = spec, ""
+    if ":" in spec:
+        head, _, tail = spec.rpartition(":")
+        # Same rule as load_graph: a trailing ':token' with no path separator is
+        # a graph name, not part of a Windows drive path.
+        if tail and "/" not in tail and "\\" not in tail:
+            path_part, suffix = head, f":{tail}"
+    # Only a .py file path is workspace-relative; a module path is not a file.
+    if path_part.endswith(".py"):
+        return f"{Path(path_part).expanduser().resolve()}{suffix}"
+    return spec
+
+
 def get_tool_arg_preview(args: Dict[str, Any]) -> str:
     """Get a preview of the first argument value (nanocode style)."""
     if not args:
@@ -1534,6 +1560,11 @@ def main(
                 print("  langstage-cli mypackage.module:agent")
                 print(f"\n{DIM}Or set the LANGSTAGE_AGENT_SPEC environment variable{RESET}")
                 sys.exit(1)
+
+        # Resolve a relative file-path spec against the invocation cwd BEFORE we
+        # chdir into the workspace root — otherwise `-a my_agent.py` is looked up
+        # under workspace_root, not where the user is and put the file. (gh #30)
+        final_spec = _absolutize_file_spec(final_spec)
 
         # Change to workspace root if specified
         if workspace_root:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.9"
+version = "0.5.10"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -1,0 +1,63 @@
+"""Relative agent-spec resolution vs the workspace-root chdir (gh #30).
+
+The CLI chdirs into LANGSTAGE_WORKSPACE_ROOT before loading the agent, so a
+relative `-a my_agent.py:graph` must be anchored to the invocation cwd up front
+— otherwise it's looked up under the workspace root and fails "file not found"
+for a file sitting in the user's current directory.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import _absolutize_file_spec, main
+
+_AGENT_SRC = (
+    "from langgraph.graph import StateGraph, START, END, MessagesState\n"
+    "from langchain_core.messages import AIMessage\n"
+    "def respond(state):\n"
+    "    return {'messages': [AIMessage(content='hi from my_agent')]}\n"
+    "g = StateGraph(MessagesState); g.add_node('respond', respond)\n"
+    "g.add_edge(START, 'respond'); g.add_edge('respond', END)\n"
+    "graph = g.compile()\n"
+)
+
+
+def test_absolutize_resolves_relative_py(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = _absolutize_file_spec("my_agent.py:graph")
+    assert out == f"{(tmp_path / 'my_agent.py').resolve()}:graph"
+
+
+def test_absolutize_bare_py_keeps_no_suffix(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = _absolutize_file_spec("my_agent.py")
+    assert out == str((tmp_path / "my_agent.py").resolve())
+    assert not out.endswith(":")
+
+
+def test_absolutize_leaves_module_specs_untouched():
+    assert _absolutize_file_spec("pkg.mod:graph") == "pkg.mod:graph"
+    assert _absolutize_file_spec("langstage_hermes.agent:graph") == "langstage_hermes.agent:graph"
+
+
+def test_absolutize_idempotent_on_absolute(tmp_path):
+    abs_spec = f"{(tmp_path / 'a.py').resolve()}:graph"
+    assert _absolutize_file_spec(abs_spec) == abs_spec
+
+
+def test_relative_spec_with_workspace_root_resolves_against_cwd(tmp_path, monkeypatch):
+    # The exact issue scenario: relative spec in cwd, workspace root elsewhere.
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (proj / "my_agent.py").write_text(_AGENT_SRC)
+    monkeypatch.chdir(proj)
+
+    r = CliRunner().invoke(
+        main,
+        ["-a", "my_agent.py:graph", "--no-interactive", "hi"],
+        env={"LANGSTAGE_WORKSPACE_ROOT": str(elsewhere)},
+    )
+    assert r.exit_code == 0, r.output
+    assert "hi from my_agent" in r.output
+    assert "not found" not in r.output.lower()


### PR DESCRIPTION
From the daily dogfood routine (Fixes #30).

## The bug
The CLI `os.chdir()`s into `LANGSTAGE_WORKSPACE_ROOT` **before** loading the agent, so a relative `-a my_agent.py:graph` was resolved against the workspace root instead of the invocation cwd. Setting the documented workspace var made `langstage-cli -a my_agent.py:graph` fail with `Agent file not found` for a file sitting right there in the current directory. Both vars are documented side-by-side, so setting both is the expected combination — and it's exactly what broke. (The earlier dogfood pass missed it because that repro used an *absolute* spec, where the chdir is harmless.)

## The fix
The file part of a relative spec is resolved to an absolute path **before** the chdir (new `_absolutize_file_spec` helper). Module specs (`pkg.mod:attr`) and already-absolute paths pass through unchanged.

## Tests
- unit: relative `.py` -> absolute (with and without `:attr`); module spec untouched; idempotent on an absolute path.
- end-to-end: a CliRunner repro of the exact issue scenario (relative spec in cwd, workspace root elsewhere) now loads and renders, instead of 'file not found'.

Full suite 50 passed; ruff check + format clean.