### PR TITLE
fix: --no-interactive auto-approves interrupts and resumes (0.5.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.11 - 2026-06-26
+
+### Fixed
+- **`--no-interactive` silently abandoned interrupts instead of auto-approving.**
+  The README documents `--no-interactive` as "auto-approve tool calls", but when
+  an agent hit a LangGraph `interrupt()` the resume loop only resolved it in
+  interactive mode — otherwise it `break`ed, dropping the interrupt and exiting 0
+  with the agent's post-interrupt work never run (a silent failure for the
+  automation/CI audience the flag exists for). It now auto-approves every pending
+  action and resumes the graph, so the agent runs to completion. (Found by the
+  dogfood routine, gh #32.)
+
 ## 0.5.10 - 2026-06-25
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -821,6 +821,17 @@ async def run_single_turn_async(
         if has_interrupt and interactive:
             decisions = handle_interrupt_input(num_pending_actions)
             input_data = prepare_agent_input(decisions=decisions)
+        elif has_interrupt:
+            # --no-interactive: auto-approve every pending action and resume, so
+            # the agent runs to completion — the documented "auto-approve tool
+            # calls" behavior — instead of silently dropping the interrupt and
+            # exiting 0 with the agent's work abandoned. (gh #32)
+            print(
+                f"{DIM}Auto-approving {num_pending_actions} pending action(s) "
+                f"(--no-interactive){RESET}"
+            )
+            decisions = [{"type": "approve"} for _ in range(num_pending_actions)]
+            input_data = prepare_agent_input(decisions=decisions)
         else:
             break
 
@@ -872,6 +883,17 @@ def run_single_turn_sync(
 
         if has_interrupt and interactive:
             decisions = handle_interrupt_input(num_pending_actions)
+            input_data = prepare_agent_input(decisions=decisions)
+        elif has_interrupt:
+            # --no-interactive: auto-approve every pending action and resume, so
+            # the agent runs to completion — the documented "auto-approve tool
+            # calls" behavior — instead of silently dropping the interrupt and
+            # exiting 0 with the agent's work abandoned. (gh #32)
+            print(
+                f"{DIM}Auto-approving {num_pending_actions} pending action(s) "
+                f"(--no-interactive){RESET}"
+            )
+            decisions = [{"type": "approve"} for _ in range(num_pending_actions)]
             input_data = prepare_agent_input(decisions=decisions)
         else:
             break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.10"
+version = "0.5.11"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_no_interactive_approve.py
+++ b/tests/test_no_interactive_approve.py
@@ -1,0 +1,45 @@
+"""--no-interactive auto-approves interrupts and resumes the graph (gh #32).
+
+Previously a LangGraph interrupt() under --no-interactive was silently dropped
+(the loop broke without resuming), so the agent's post-interrupt work never ran
+and the turn exited 0 looking successful. --no-interactive is documented as
+"auto-approve tool calls", so it must approve all pending actions and resume.
+"""
+
+import textwrap
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_HITL_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+    from langchain_core.messages import AIMessage
+
+    def ask(state):
+        decision = interrupt({"question": "Approve this action?"})
+        return {"messages": [AIMessage(content=f"Decision was: {decision}")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("ask", ask)
+    g.add_edge(START, "ask")
+    g.add_edge("ask", END)
+    graph = g.compile(checkpointer=MemorySaver())
+    """
+)
+
+
+def test_no_interactive_auto_approves_and_resumes(tmp_path, monkeypatch):
+    (tmp_path / "hitl_agent.py").write_text(_HITL_AGENT)
+    monkeypatch.chdir(tmp_path)
+
+    r = CliRunner().invoke(main, ["-a", "hitl_agent.py:graph", "go", "--no-interactive"])
+    assert r.exit_code == 0, r.output
+    # The interrupt was auto-approved and the graph resumed — the post-interrupt
+    # node ran and rendered its content, instead of the interrupt being dropped.
+    assert "Auto-approving" in r.output
+    assert "Decision was:" in r.output


### PR DESCRIPTION
From the daily dogfood routine (Fixes #32).

## The bug (major)
The README documents `--no-interactive` as **"auto-approve tool calls"**, and `--help` implies it still *handles* interrupts without prompting. But when an agent hit a LangGraph `interrupt()` under `--no-interactive`, the resume loop only resolved it when `interactive` was true — otherwise it `break`ed, **dropping the interrupt and exiting 0** with the agent's post-interrupt node never run. For the automation/CI audience the flag exists for, the run *looked* successful but the agent never completed.

## The fix
In both the sync and async turn helpers, when an interrupt fires under `--no-interactive`, auto-approve every pending action (`{"type": "approve"}` × N — the non-interactive equivalent of "Approve all actions") and resume the graph, so the agent runs to completion. A one-line `Auto-approving N pending action(s)` notice makes the choice visible.

## Test
A HITL agent that calls `interrupt()` now runs to completion under `--no-interactive` (its post-interrupt content renders), instead of the interrupt being silently dropped.

Full suite 51 passed; ruff check + format clean.
