### PR TITLE
fix: print the streaming bullet once per turn, not per token (0.5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.12 - 2026-06-27
+
+### Fixed
+- **Token streaming jammed the `⏺` marker before every token.** A token-streaming
+  model emits one chunk per token, and `print_chunk` prefixed the cyan bullet on
+  *every* streaming chunk — so a real LLM reply rendered as
+  `⏺ alpha⏺  ⏺ beta⏺  ⏺ gamma` instead of `⏺ alpha beta gamma`. This hit the
+  default `auto` mode (and `messages`); only `updates` (one whole-message chunk)
+  escaped it. The marker is now printed once at the start of a streamed AI turn,
+  reset on any non-text event (tool call, interrupt, complete) and at each turn
+  start. (Found by the dogfood routine, gh #34.)
+
 ## 0.5.11 - 2026-06-26
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -583,11 +583,19 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
             if verbose:
                 print(f"{DIM}[{node}]{RESET} {text}", end="")
             else:
-                # Print text output with cyan bullet
-                print(f"{CYAN}⏺{RESET} {render_markdown(text)}", end="")
+                # Print the cyan bullet ONCE at the start of a streamed AI turn,
+                # then append subsequent tokens with no marker. A token-streaming
+                # model emits one chunk per token, so prefixing the marker on
+                # every chunk jammed a `⏺` before every token. (gh #34)
+                if print_chunk._streaming_text:
+                    print(render_markdown(text), end="")
+                else:
+                    print(f"{CYAN}⏺{RESET} {render_markdown(text)}", end="")
+                    print_chunk._streaming_text = True
 
         # Handle tool calls - green tool name
         elif "tool_calls" in chunk:
+            print_chunk._streaming_text = False  # a non-text event ends the text run
             for tool_call in chunk["tool_calls"]:
                 tool_name = tool_call["name"]
                 args = tool_call.get("args", {})
@@ -599,11 +607,13 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
 
         # Handle tool results - indented with result preview
         elif "tool_result" in chunk:
+            print_chunk._streaming_text = False
             result = chunk.get("tool_result", "")
             preview = format_result_preview(str(result))
             print(f"  {DIM}   ↳ {preview}{RESET}")
 
     elif status == "interrupt":
+        print_chunk._streaming_text = False
         interrupt_data = chunk.get("interrupt", {})
         action_requests = interrupt_data.get("action_requests", [])
 
@@ -617,11 +627,18 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
                     print(f"     {DIM}└─ {args_preview}{RESET}")
 
     elif status == "complete":
-        pass  # No output on complete (nanocode style)
+        print_chunk._streaming_text = False  # turn over; next turn starts a fresh marker
 
     elif status == "error":
+        print_chunk._streaming_text = False
         error_msg = chunk.get("error", "Unknown error")
         print(f"\n{RED}✗ Error: {error_msg}{RESET}")
+
+
+# Whether the current AI turn has already emitted its leading cyan bullet. Tracked
+# across per-chunk print_chunk() calls so a token-streamed reply gets one marker,
+# not one per token (gh #34). Reset on any non-text event and at each turn start.
+print_chunk._streaming_text = False
 
 
 def get_key() -> str:
@@ -787,6 +804,7 @@ async def run_single_turn_async(
     """Run a single turn of an async LangGraph graph. Returns total duration in seconds."""
     input_data = prepare_agent_input(message=message)
     lg_stream_mode = _resolve_stream_mode(stream_mode)
+    print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
     start_time = time.time()
 
     while True:
@@ -849,6 +867,7 @@ def run_single_turn_sync(
     """Run a single turn of a sync LangGraph graph. Returns total duration in seconds."""
     input_data = prepare_agent_input(message=message)
     lg_stream_mode = _resolve_stream_mode(stream_mode)
+    print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
     start_time = time.time()
 
     while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.11"
+version = "0.5.12"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_streaming_marker.py
+++ b/tests/test_streaming_marker.py
@@ -1,0 +1,62 @@
+"""Token streaming prints the cyan bullet once per turn, not per token (gh #34).
+
+A token-streaming model emits one chunk per token; the CLI used to prefix the
+`⏺` marker on every chunk, jamming a bullet before every token and garbling the
+reply. The marker must print once at the start of a streamed AI turn.
+"""
+
+import textwrap
+
+from click.testing import CliRunner
+
+from langstage_cli import cli as c
+from langstage_cli.cli import main
+
+
+def test_marker_printed_once_per_text_run(capsys):
+    c.print_chunk._streaming_text = False
+    # A run of streamed text tokens -> ONE marker.
+    for tok in ["a", "b", "c"]:
+        c.print_chunk({"status": "streaming", "chunk": tok})
+    # A tool call ends the text run...
+    c.print_chunk({"status": "streaming", "tool_calls": [{"name": "t", "args": {}}]})
+    # ...so the next run of text gets a fresh marker.
+    for tok in ["d", "e"]:
+        c.print_chunk({"status": "streaming", "chunk": tok})
+
+    out = capsys.readouterr().out
+    assert out.count("⏺") == 2, out  # one per text run, NOT one per token (which would be 5)
+
+
+_TOK_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langchain_core.messages import AIMessage
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+    # GenericFakeChatModel streams its content token-by-token, like a real LLM.
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="alpha beta gamma")]))
+
+    def respond(state):
+        return {"messages": [model.invoke(state["messages"])]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("respond", respond)
+    g.add_edge(START, "respond")
+    g.add_edge("respond", END)
+    graph = g.compile()
+    """
+)
+
+
+def test_token_stream_renders_one_marker_end_to_end(tmp_path, monkeypatch):
+    (tmp_path / "tok.py").write_text(_TOK_AGENT)
+    monkeypatch.chdir(tmp_path)
+
+    r = CliRunner().invoke(main, ["-a", "tok.py:graph", "hi", "--no-interactive"])
+    assert r.exit_code == 0, r.output
+    # Exactly one bullet for the whole streamed turn, not one per token.
+    assert r.output.count("⏺") == 1, r.output
+    for word in ("alpha", "beta", "gamma"):
+        assert word in r.output, r.output


### PR DESCRIPTION
From the daily dogfood routine (Fixes #34).

## The bug (major)
langstage-cli's marquee feature — streaming a real LLM agent — was mangled on the **default** code path. A token-streaming model (Anthropic, OpenAI/OpenRouter, …) emits one chunk per token, and `print_chunk` prefixed the cyan `⏺` marker on **every** streaming chunk. So a reply that should render

```
⏺ alpha beta gamma
```

actually rendered

```
⏺ alpha⏺  ⏺ beta⏺  ⏺ gamma
```

This hit the default `auto` mode and `messages`; only `updates` (one whole-message chunk) escaped it, so it looked fine in quick whole-message tests but garbled every real streamed answer.

## The fix
Print the `⏺` marker **once** at the start of a streamed AI turn, then append subsequent tokens with no marker. The "started" flag resets on any non-text event (tool call, tool result, interrupt, complete, error) and at each turn start — so a tool call mid-turn correctly starts a fresh marker for the next run of text.

## Tests
- unit: a run of streamed tokens renders one marker; a tool call between two runs yields exactly two (not one-per-token).
- end-to-end: a CliRunner run against a token-streaming `GenericFakeChatModel` agent renders **exactly one** marker and the full reply.

Full suite 53 passed; ruff check + format clean.

> Note: the secondary point in the issue — `render_markdown` applied per token (can't render markdown spanning token boundaries) — is left for a follow-up; it needs whole-turn buffering and isn't the visible defect.
