### PR TITLE
show-config/config: omit server-only keys the CLI ignores (#36)

### DIFF
--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -53,6 +53,12 @@ MAGENTA, WHITE, GRAY = "\033[35m", "\033[37m", "\033[90m"
 BRIGHT_CYAN, BRIGHT_BLUE = "\033[96m", "\033[94m"
 BRIGHT_GREEN, BRIGHT_YELLOW = "\033[92m", "\033[93m"
 
+# Inherited HostConfig keys the terminal CLI never reads: it starts no server
+# (host/port/debug are inert) and the header box uses the loaded graph's name,
+# not `title`. `--show-config` / `/config` omit these so the diagnostic only
+# advertises knobs this surface actually honors. (gh #36)
+_INERT_KEYS = ["host", "port", "debug", "title"]
+
 # Spinner frames for thinking animation
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
@@ -1061,7 +1067,11 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
         # / TOML key that sets it.
         from langstage_cli.config import CodeConfig
 
-        for line in CodeConfig.resolve().describe().splitlines():
+        # Omit the inherited server/web keys the terminal CLI never honors: it
+        # starts no server (host/port/debug inert) and the header uses the graph
+        # name, not `title`. Advertising them with source attribution is the
+        # "advertised != honored" trap. (gh #36)
+        for line in CodeConfig.resolve().describe(omit_keys=_INERT_KEYS).splitlines():
             print(f"  {line}")
 
         configurable = config.get("configurable", {})
@@ -1532,10 +1542,11 @@ def main(
     }
 
     if show_config:
+        # See _INERT_KEYS: hide the server/web keys this surface ignores. (gh #36)
         print(
             config_module.CodeConfig.resolve(
                 toml_start=Path.cwd(), overrides=cli_overrides
-            ).describe()
+            ).describe(omit_keys=_INERT_KEYS)
         )
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.12"
+version = "0.5.13"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -45,3 +45,26 @@ def test_show_config_without_flags_still_reports_env():
     assert r.exit_code == 0, r.output
     # no flags → env is correctly the winning source (no regression)
     assert re.search(r"agent_spec\s*=\s*fromenv\.py:graph\s*\[env:", r.output), r.output
+
+
+def test_show_config_omits_server_only_keys():
+    """The terminal CLI starts no server and titles the header from the graph
+    name, so host/port/debug/title are inert and must not be advertised. (gh #36)"""
+    with CliRunner().isolated_filesystem():
+        r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    for key in ("host", "port", "debug", "title"):
+        assert not re.search(rf"^\s*{key}\s*=", r.output, re.MULTILINE), f"{key} should be omitted"
+    # ...but keys the CLI actually honors are still shown.
+    assert re.search(r"^\s*agent_spec\s*=", r.output, re.MULTILINE), r.output
+    assert re.search(r"^\s*stream_mode\s*=", r.output, re.MULTILINE), r.output
+
+
+def test_show_config_title_env_not_advertised_as_effective():
+    """Setting LANGSTAGE_TITLE must not show up as an in-effect value on a surface
+    that ignores it (it would mislead the user). (gh #36)"""
+    with CliRunner().isolated_filesystem():
+        r = CliRunner().invoke(main, ["--show-config"], env={"LANGSTAGE_TITLE": "MyCoolAgent"})
+    assert r.exit_code == 0, r.output
+    assert "MyCoolAgent" not in r.output
+    assert not re.search(r"^\s*title\s*=", r.output, re.MULTILINE)


### PR DESCRIPTION
## Problem

`langstage-cli --show-config` (and `/config`) printed `host`, `port`, `debug`, and `title` with confident source attribution — but the terminal CLI never reads any of them. It starts no server (so host/port/debug are inert), and the header box title comes from the loaded graph's name, not `title`/`LANGSTAGE_TITLE`. Setting `LANGSTAGE_TITLE` even made `--show-config` report it as a resolved, in-effect value. The diagnostic that exists to tell users which knobs work was advertising four that do nothing here.

Fixes #36.

## Fix

Pass `omit_keys=["host", "port", "debug", "title"]` to `HostConfig.describe()` at both call sites (`--show-config` and `/config`). The shared resolver already ships this mechanism for exactly this surface. `--show-config` now lists only the keys the terminal CLI honors: `agent_spec`, `workspace_root`, `stream_mode`, `graph_name`, `verbose`, `async_mode`.

## Tests

`tests/test_show_config.py`: host/port/debug/title are omitted; honored keys remain; `LANGSTAGE_TITLE` no longer shows as an effective value. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
