### PR TITLE
Auto-attach a checkpointer so the conversation loop has memory (#38)

### DIFF
--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -496,7 +496,30 @@ def load_graph(spec: str, default_graph_name: str = "graph"):
             graph_name = tail or default_graph_name
 
     graph = load_agent_spec(f"{path_or_module}:{graph_name}")
+    _ensure_checkpointer(graph)
     return graph, graph_name
+
+
+def _ensure_checkpointer(graph: Any) -> None:
+    """Attach an in-memory checkpointer if the graph has none.
+
+    The interactive loop sends only the latest message each turn and relies on
+    the graph's checkpointer (keyed by ``configurable.thread_id``) for multi-turn
+    memory. Many bring-your-own graphs — including the README's own minimal
+    example — compile without one, which left the "conversation loop" amnesiac
+    and ``/history`` erroring ("No checkpointer set"). Auto-attach an in-memory
+    default (same as the web stage) so memory and ``/history`` work out of the
+    box; a user-supplied checkpointer is left untouched. Pass your own (durable)
+    checkpointer for persistence across runs. (gh #38)
+    """
+    if getattr(graph, "checkpointer", None) is not None:
+        return
+    try:
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        graph.checkpointer = InMemorySaver()
+    except Exception:  # noqa: BLE001 - best effort; the loop still runs, just stateless
+        pass
 
 
 def _absolutize_file_spec(spec: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.13"
+version = "0.5.14"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -1,0 +1,49 @@
+"""The CLI auto-attaches a checkpointer so the conversation loop has memory (gh #38).
+
+The interactive loop sends only the latest message each turn and relies on the
+graph's checkpointer (keyed by thread_id) for multi-turn memory. A bring-your-own
+graph compiled without one — like the README's minimal example — used to be
+amnesiac (every turn saw one message) and /history errored "No checkpointer set".
+The loader now attaches an in-memory default when the graph has none.
+"""
+
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from langstage_cli.cli import _ensure_checkpointer
+
+
+def _counting_graph(checkpointer=None):
+    def respond(state):
+        return {"messages": [AIMessage(content=f"n={len(state['messages'])}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("respond", respond)
+    b.add_edge(START, "respond")
+    b.add_edge("respond", END)
+    return b.compile(checkpointer=checkpointer)
+
+
+def test_attaches_checkpointer_when_absent():
+    g = _counting_graph()
+    assert getattr(g, "checkpointer", None) is None
+    _ensure_checkpointer(g)
+    assert g.checkpointer is not None
+
+
+def test_leaves_user_supplied_checkpointer_untouched():
+    saver = InMemorySaver()
+    g = _counting_graph(checkpointer=saver)
+    _ensure_checkpointer(g)
+    assert g.checkpointer is saver
+
+
+def test_memory_accumulates_across_turns():
+    g = _counting_graph()
+    _ensure_checkpointer(g)
+    cfg = {"configurable": {"thread_id": "t1"}}
+    g.invoke({"messages": [("user", "first")]}, cfg)
+    out = g.invoke({"messages": [("user", "second")]}, cfg)
+    # Turn 2 sees the prior turn's messages (memory works), not just the latest.
+    assert len(out["messages"]) >= 3


### PR DESCRIPTION
## Problem

`langstage-cli` is sold as an "interactive conversation loop" and ships `/clear` and `/history` — all implying it keeps conversation state across turns. It doesn't: it sends only the latest message each turn (`prepare_agent_input(message=...)`) and delegates *all* multi-turn memory to the graph's own checkpointer (keyed by `configurable.thread_id`). The README's own "Creating Your Own Agent" minimal example compiles **without a checkpointer**, so a user who follows the README gets an "interactive conversation loop" with complete amnesia — every turn the agent sees exactly one message, and `/history` errors with `No checkpointer set`.

```
$ printf 'first\nsecond\nthird\n/quit\n' | langstage-cli -a count_agent.py:graph
I currently see 1 message(s) in state.
I currently see 1 message(s) in state.   # never grows
I currently see 1 message(s) in state.
```

Fixes #38.

## Fix

After loading the agent, attach an in-memory checkpointer when the graph has none — the same thing the web stage already does. A user-supplied checkpointer is left untouched (pass your own durable one for persistence across runs).

```
I currently see 1 message(s) in state.
I currently see 3 message(s) in state.   # memory accumulates
I currently see 5 message(s) in state.
```

`/history` now shows the conversation instead of erroring.

## Tests

`tests/test_checkpointer.py`: attaches when absent, leaves a user checkpointer untouched, and memory accumulates across turns on the same thread. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
