### PR TITLE
Print the verbose [node] label once per run, not per token (#40)

### DIFF
--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -610,7 +610,18 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
             text = chunk["chunk"]
             node = chunk.get("node", "unknown")
             if verbose:
-                print(f"{DIM}[{node}]{RESET} {text}", end="")
+                # Print the [node] label ONCE per streamed run — when a text run
+                # starts, or the node changes mid-stream — then append subsequent
+                # tokens with no label. A token-streaming model emits one chunk per
+                # token, so prefixing [node] on every chunk jammed it before every
+                # token. The #34 fix covered only the non-verbose branch. (gh #40)
+                if not print_chunk._streaming_text or print_chunk._streaming_node != node:
+                    if print_chunk._streaming_text:
+                        print()  # node changed mid-run — break before the new label
+                    print(f"{DIM}[{node}]{RESET} ", end="")
+                    print_chunk._streaming_node = node
+                    print_chunk._streaming_text = True
+                print(text, end="")
             else:
                 # Print the cyan bullet ONCE at the start of a streamed AI turn,
                 # then append subsequent tokens with no marker. A token-streaming
@@ -668,6 +679,9 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
 # across per-chunk print_chunk() calls so a token-streamed reply gets one marker,
 # not one per token (gh #34). Reset on any non-text event and at each turn start.
 print_chunk._streaming_text = False
+# The node whose tokens are currently streaming, so verbose mode prints the
+# [node] label once per run instead of before every token (gh #40).
+print_chunk._streaming_node = None
 
 
 def get_key() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.14"
+version = "0.5.15"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_streaming_marker.py
+++ b/tests/test_streaming_marker.py
@@ -60,3 +60,38 @@ def test_token_stream_renders_one_marker_end_to_end(tmp_path, monkeypatch):
     assert r.output.count("⏺") == 1, r.output
     for word in ("alpha", "beta", "gamma"):
         assert word in r.output, r.output
+
+
+# gh #40: the verbose branch must print the [node] label once per run too,
+# not before every token (the #34 fix only covered the non-verbose branch).
+
+
+def test_verbose_node_label_printed_once_per_run(capsys):
+    c.print_chunk._streaming_text = False
+    c.print_chunk._streaming_node = None
+    for tok in ["a", "b", "c"]:
+        c.print_chunk({"status": "streaming", "chunk": tok, "node": "respond"}, verbose=True)
+    out = capsys.readouterr().out
+    assert out.count("[respond]") == 1, out  # one label, NOT one per token (3)
+    assert "a" in out and "b" in out and "c" in out  # the tokens still stream
+
+
+def test_verbose_label_reprints_after_a_tool_call(capsys):
+    c.print_chunk._streaming_text = False
+    c.print_chunk._streaming_node = None
+    for tok in ["a", "b"]:
+        c.print_chunk({"status": "streaming", "chunk": tok, "node": "respond"}, verbose=True)
+    c.print_chunk({"status": "streaming", "tool_calls": [{"name": "t", "args": {}}]}, verbose=True)
+    for tok in ["c", "d"]:
+        c.print_chunk({"status": "streaming", "chunk": tok, "node": "respond"}, verbose=True)
+    out = capsys.readouterr().out
+    assert out.count("[respond]") == 2, out  # one per text run
+
+
+def test_verbose_label_reprints_on_node_change(capsys):
+    c.print_chunk._streaming_text = False
+    c.print_chunk._streaming_node = None
+    c.print_chunk({"status": "streaming", "chunk": "x", "node": "alpha"}, verbose=True)
+    c.print_chunk({"status": "streaming", "chunk": "y", "node": "beta"}, verbose=True)
+    out = capsys.readouterr().out
+    assert out.count("[alpha]") == 1 and out.count("[beta]") == 1, out


### PR DESCRIPTION
## Problem

Issue #34 (the `⏺` marker prepended to every token) was fixed in 0.5.12 by printing the marker **once per turn** — but only in the **non-verbose** branch. The **verbose** branch (`-v` / `--verbose`, and the documented `[ui] verbose = true` TOML key) still prefixes `[{node}]` on **every streamed token**:

```
[respond] (demo [respond] agent) [respond] You [respond] said: [respond] hi ...
```

Every real LLM token-streams its reply, so any verbose run against a real model is mangled — and the README's own example `langstage.toml` sets `verbose = true`, so a user copying it hits this with no flag at all.

Fixes #40.

## Fix

Mirror the #34 marker-once logic in the verbose branch: print the `[{node}]` label **once** when a text run starts, re-print it only when a tool call ends the run or the node changes mid-stream, then append subsequent tokens with no label. Tracked via a new `print_chunk._streaming_node` alongside `_streaming_text`.

```
[respond] (demo agent) You said: hi there world      # one label, clean stream
```

## Tests

`tests/test_streaming_marker.py`: label printed once per run, re-printed after a tool call, re-printed on node change. 5 passed; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
