### PR TITLE
feat(cli): experimental --agui in-process streaming path (ADR 0002)

### DIFF
--- a/langstage_cli/agui_stream.py
+++ b/langstage_cli/agui_stream.py
@@ -1,0 +1,102 @@
+"""Experimental in-process AG-UI streaming path for the cli (``--agui``).
+
+Instead of parsing ``graph.stream()`` via ``langgraph-stream-parser``'s event
+layer, this drives the agent through the official ``ag-ui-langgraph`` adapter
+in-process (no web server) and maps AG-UI events onto the cli's existing
+``print_chunk`` chunk contract — so the renderer is unchanged.
+
+This is the first step of ADR 0002 (retire the bespoke event layer, converge on
+AG-UI). Text + tool calls/results are at parity with the default path (and the
+AG-UI path additionally surfaces tool *results*). Interrupt **display** works;
+interrupt **resume** is not yet supported here (ADR 0002 gate 2) — the caller
+surfaces a notice and the user re-runs on the default path to approve actions.
+
+Requires the ``agui`` extra::
+
+    pip install "langstage-cli[agui]"
+"""
+
+import json
+import uuid
+from typing import Any, AsyncIterator, Dict
+
+_IMPORT_HINT = 'the --agui path needs the agui extra: pip install "langstage-cli[agui]"'
+
+
+def ensure_agui_available() -> None:
+    """Raise a clean, actionable error if the AG-UI adapter isn't installed."""
+    try:
+        import ag_ui_langgraph  # noqa: F401
+        from langgraph_stream_parser.agui import build_agent  # noqa: F401
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(_IMPORT_HINT) from e
+
+
+def build_session_agent(graph: Any, *, name: str = "langstage-cli") -> Any:
+    """Wrap a compiled graph once per session (checkpointer attached by the core
+    bridge), so multi-turn memory persists across turns."""
+    ensure_agui_available()
+    from langgraph_stream_parser.agui import build_agent
+
+    return build_agent(graph, name=name)
+
+
+async def agui_stream_updates(
+    agent: Any, message: str, thread_id: str
+) -> AsyncIterator[Dict[str, Any]]:
+    """Drive ``agent.run()`` in-process and yield ``print_chunk``-compatible chunks.
+
+    Maps: TextMessageContent -> text; ToolCall{Start,Args,End} -> tool_calls;
+    ToolCallResult -> tool_result; CustomEvent(on_interrupt) -> interrupt;
+    RunError -> error; and a one-shot MessagesSnapshot -> text when nothing streamed.
+    Always terminates with a ``complete`` chunk.
+    """
+    from ag_ui.core.types import RunAgentInput, UserMessage
+
+    run_input = RunAgentInput(
+        thread_id=thread_id,
+        run_id=str(uuid.uuid4()),
+        state={},
+        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+    streamed_text = False
+    tool_buf: Dict[str, Dict[str, str]] = {}
+
+    async for ev in agent.run(run_input):
+        t = type(ev).__name__
+        if t == "TextMessageContentEvent":
+            streamed_text = True
+            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
+        elif t == "ToolCallStartEvent":
+            tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
+        elif t == "ToolCallArgsEvent":
+            tool_buf.setdefault(ev.tool_call_id, {"name": "tool", "args": ""})["args"] += ev.delta
+        elif t == "ToolCallEndEvent":
+            tc = tool_buf.pop(ev.tool_call_id, {"name": "tool", "args": ""})
+            try:
+                args = json.loads(tc["args"]) if tc["args"] else {}
+            except json.JSONDecodeError:
+                args = {"_raw": tc["args"]}
+            yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
+        elif t == "ToolCallResultEvent":
+            yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
+        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
+            payload = getattr(ev, "value", None)
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {"action_requests": []}
+            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
+        elif t == "MessagesSnapshotEvent" and not streamed_text:
+            for m in ev.messages:
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
+                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
+        elif t == "RunErrorEvent":
+            yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
+
+    yield {"status": "complete"}

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1297,12 +1297,56 @@ def setup_readline_completion():
         readline.parse_and_bind("tab: complete")
 
 
+async def run_single_turn_agui(
+    agent,
+    message: str,
+    thread_id: str,
+    interactive: bool = True,
+    verbose: bool = False,
+) -> float:
+    """Experimental ``--agui`` path: stream a turn through the in-process AG-UI
+    adapter, rendering with the same ``print_chunk``. Text + tool calls/results
+    reach parity with the default path (and tool *results* are also shown).
+
+    An interrupt is DISPLAYED but not resumable here (ADR 0002 gate 2): we surface
+    a notice and return, so the user re-runs on the default path to approve actions.
+    """
+    from langstage_cli.agui_stream import agui_stream_updates
+
+    print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
+    start_time = time.time()
+    saw_interrupt = False
+    first_chunk = True
+    spinner = Spinner("Thinking")
+    spinner.start()
+    try:
+        async for chunk in agui_stream_updates(agent, message, thread_id):
+            if first_chunk:
+                spinner.stop()
+                first_chunk = False
+            print_chunk(chunk, verbose=verbose)
+            if chunk.get("status") == "interrupt":
+                saw_interrupt = True
+    finally:
+        spinner.stop()
+
+    if saw_interrupt:
+        print(
+            f"\n{YELLOW}⚠ The experimental --agui path can display interrupts but "
+            f"can't resume them yet (ADR 0002 gate 2).{RESET}"
+        )
+        print(f"{DIM}  Re-run without --agui to approve or edit pending actions.{RESET}")
+
+    return time.time() - start_time
+
+
 def run_conversation_loop(
     graph,
     config: Dict[str, Any],
     agent_name: str = "AgentCode",
     agent_description: Optional[str] = None,
     use_async: bool = False,
+    use_agui: bool = False,
     interactive: bool = True,
     verbose: bool = False,
     stream_mode: str = "updates",
@@ -1335,13 +1379,33 @@ def run_conversation_loop(
         "stream_mode": stream_mode,
     }
 
+    # Experimental --agui: build the in-process AG-UI agent ONCE per session
+    # (checkpointer attached by the core bridge) so multi-turn memory persists.
+    agui_agent = None
+    thread_id = ""
+    if use_agui:
+        if isinstance(config, dict):
+            thread_id = config.get("configurable", {}).get("thread_id", "") or ""
+        from langstage_cli.agui_stream import build_session_agent
+
+        try:
+            agui_agent = build_session_agent(graph, name=agent_name)
+        except RuntimeError as e:
+            print(f"{RED}⏺ {e}{RESET}")
+            return
+        print(f"{DIM}(experimental --agui: streaming via in-process AG-UI){RESET}")
+
     # Process initial message if provided
     if initial_message:
         print(f"\n{BOLD}{BRIGHT_BLUE}You{RESET}")
         print(f"{initial_message}")
         print()
 
-        if use_async:
+        if use_agui:
+            duration = asyncio.run(
+                run_single_turn_agui(agui_agent, initial_message, thread_id, interactive, verbose)
+            )
+        elif use_async:
             duration = asyncio.run(
                 run_single_turn_async(
                     graph, initial_message, config, interactive, verbose, stream_mode
@@ -1419,7 +1483,11 @@ def run_conversation_loop(
             print()  # Space before response
 
             # Run the agent
-            if use_async:
+            if use_agui:
+                duration = asyncio.run(
+                    run_single_turn_agui(agui_agent, user_input, thread_id, interactive, verbose)
+                )
+            elif use_async:
                 duration = asyncio.run(
                     run_single_turn_async(
                         graph, user_input, config, interactive, verbose, stream_mode
@@ -1494,6 +1562,14 @@ def run_conversation_loop(
     help="Run with the built-in keyless demo agent (no API key needed)",
 )
 @click.option(
+    "--agui",
+    is_flag=True,
+    default=False,
+    help="[experimental] Stream via the in-process AG-UI adapter instead of the "
+    "built-in event parser (text + tool calls/results; interrupts display only). "
+    'Requires the agui extra: pip install "langstage-cli[agui]".',
+)
+@click.option(
     "--show-config",
     "show_config",
     is_flag=True,
@@ -1510,6 +1586,7 @@ def main(
     stream_mode: Optional[str],
     verbose: Optional[bool],
     demo: bool,
+    agui: bool,
     show_config: bool,
 ):
     """
@@ -1691,6 +1768,7 @@ def main(
             agent_name=agent_name,
             agent_description=agent_description,
             use_async=use_async,
+            use_agui=agui,
             interactive=interactive,
             verbose=verbose,
             stream_mode=final_stream_mode,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.15"
+version = "0.5.16"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -44,6 +44,10 @@ dev = [
     # the example/tests run, but don't make every `pip install langstage-cli`
     # pull deepagents + langchain + langgraph.
     "deepagents>=0.3",
+    # The experimental --agui path (ADR 0002); pulled into dev so CI exercises
+    # tests/test_agui_stream.py instead of skipping it.
+    "ag-ui-langgraph>=0.0.41",
+    "fastapi",
 ]
 agui = ["langgraph-stream-parser[agui]>=0.6.6,<0.7"]
 

--- a/tests/test_agui_stream.py
+++ b/tests/test_agui_stream.py
@@ -1,0 +1,119 @@
+"""Tests for the experimental in-process AG-UI streaming path (--agui, ADR 0002).
+
+Skipped unless the agui extra is installed. The dev extra pulls it so CI runs these.
+"""
+
+import asyncio
+from typing import Iterator, List
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langchain_core.language_models.chat_models import BaseChatModel  # noqa: E402
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage  # noqa: E402
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult  # noqa: E402
+from langchain_core.tools import tool  # noqa: E402
+from langgraph.checkpoint.memory import InMemorySaver  # noqa: E402
+from langgraph.graph import END, START, MessagesState, StateGraph  # noqa: E402
+from langgraph.types import interrupt  # noqa: E402
+from langgraph_stream_parser import load_agent_spec  # noqa: E402
+
+from langstage_cli.agui_stream import agui_stream_updates, build_session_agent  # noqa: E402
+
+
+def _collect(agent, msg: str) -> List[dict]:
+    async def go():
+        return [c async for c in agui_stream_updates(agent, msg, "t-test")]
+
+    return asyncio.run(go())
+
+
+def test_text_parity_on_demo_stub():
+    """The keyless echo stub round-trips through AG-UI and reflects the input."""
+    agent = build_session_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    chunks = _collect(agent, "hello agui test")
+    text = "".join(c["chunk"] for c in chunks if "chunk" in c)
+    assert "hello agui test" in text
+    assert chunks[-1]["status"] == "complete"
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the weather."""
+    return "Sunny, 72F"
+
+
+class _FakeToolModel(BaseChatModel):
+    @property
+    def _llm_type(self) -> str:
+        return "fake-tool"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _stream(
+        self, messages: List[BaseMessage], stop=None, run_manager=None, **kwargs
+    ) -> Iterator[ChatGenerationChunk]:
+        if any(isinstance(m, ToolMessage) for m in messages):
+            for tok in ["It's ", "72F."]:
+                yield ChatGenerationChunk(message=AIMessageChunk(content=tok))
+        else:
+            yield ChatGenerationChunk(
+                message=AIMessageChunk(
+                    content="",
+                    tool_call_chunks=[{"name": "get_weather", "args": "", "id": "c1", "index": 0}],
+                )
+            )
+            for seg in ('{"city": ', '"Portland"}'):
+                yield ChatGenerationChunk(
+                    message=AIMessageChunk(
+                        content="",
+                        tool_call_chunks=[{"name": None, "args": seg, "id": None, "index": 0}],
+                    )
+                )
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        chunks = list(self._stream(messages, stop=stop, run_manager=run_manager, **kwargs))
+        msg = chunks[0].message
+        for c in chunks[1:]:
+            msg = msg + c.message
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content=msg.content, tool_calls=getattr(msg, "tool_calls", [])
+                    )
+                )
+            ]
+        )
+
+
+def test_tool_call_and_result_map_to_chunks():
+    from langgraph.prebuilt import create_react_agent
+
+    agent = build_session_agent(create_react_agent(_FakeToolModel(), [get_weather]))
+    chunks = _collect(agent, "weather?")
+    tool_calls = [c["tool_calls"][0] for c in chunks if "tool_calls" in c]
+    assert tool_calls and tool_calls[0]["name"] == "get_weather"
+    assert tool_calls[0]["args"] == {"city": "Portland"}  # args reconstructed from deltas
+    assert any("tool_result" in c for c in chunks)  # AG-UI surfaces the tool result
+    assert "72F" in "".join(c["chunk"] for c in chunks if "chunk" in c)
+
+
+def test_interrupt_surfaces_as_interrupt_chunk():
+    def gate(state):
+        decision = interrupt({"action_requests": [{"tool": "approve", "args": {"x": 1}}]})
+        return {"messages": [AIMessage(content=f"ok {decision}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("gate", gate)
+    b.add_edge(START, "gate")
+    b.add_edge("gate", END)
+    agent = build_session_agent(b.compile(checkpointer=InMemorySaver()))
+
+    chunks = _collect(agent, "go")
+    interrupts = [c for c in chunks if c.get("status") == "interrupt"]
+    assert interrupts, chunks
+    assert interrupts[0]["interrupt"]["action_requests"][0]["tool"] == "approve"


### PR DESCRIPTION
## What

First concrete step of **ADR 0002** (retire the bespoke event layer, converge on AG-UI): an **experimental `--agui` flag** that streams a turn through the official `ag-ui-langgraph` adapter **in-process** (no web server) and maps AG-UI events onto the cli's existing `print_chunk` contract — so the renderer is **unchanged**.

This is the outcome of the cli-first spike (branch `spike/cli-agui-inprocess`), promoted to real, flag-gated code.

## How

- **`langstage_cli/agui_stream.py`** (new):
  - `build_session_agent()` wraps the graph **once per session** via the core's `agui.build_agent` (checkpointer attached → multi-turn memory persists).
  - `agui_stream_updates()` maps `TextMessageContent → text`, `ToolCall{Start,Args,End} → tool_calls`, `ToolCallResultEvent → tool_result`, `CustomEvent(on_interrupt) → interrupt`, `RunError → error`, and a one-shot `MessagesSnapshot → text`. Always ends with `complete`.
- **`cli.py`**: `--agui` flag (experimental; requires the `[agui]` extra) + a `run_single_turn_agui()` runner; both dispatch sites route to it. **The default path is untouched.**

## Parity (from the spike, now tested)

- Text + tool call/args + final text: **parity** with the default path.
- **Bonus:** the AG-UI path also surfaces the **tool result** (`↳ …`), which the current `updates` mode doesn't emit.
- **Interrupts: display only.** An interrupt renders, then the runner prints a clear notice that resume isn't supported on `--agui` yet (**ADR 0002 gate 2**) and to use the default path to approve actions — it does not hang or silently drop.

## Tests

`tests/test_agui_stream.py`: text parity on the demo stub, tool call+result mapping (keyless streaming react agent), interrupt detection. Added `ag-ui-langgraph` + `fastapi` to the **dev extra** so CI runs them (they `importorskip` otherwise). Full suite: 64 passed; `ruff check` + `ruff format --check` clean.

## Known limits (intentional, documented)

- Requires the `[agui]` extra; cleanest once **ag-ui-protocol/ag-ui#2067** lands (the eager-import that currently forces fastapi).
- **Interrupt resume** is deferred to gate 2 — the same round-trip the web/vscode HITL surfaces need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
