### PR TITLE
feat(cli): --agui interrupts now resume (ADR 0002 gate 2 resolved)

### DIFF
--- a/langstage_cli/agui_stream.py
+++ b/langstage_cli/agui_stream.py
@@ -7,9 +7,9 @@ in-process (no web server) and maps AG-UI events onto the cli's existing
 
 This is the first step of ADR 0002 (retire the bespoke event layer, converge on
 AG-UI). Text + tool calls/results are at parity with the default path (and the
-AG-UI path additionally surfaces tool *results*). Interrupt **display** works;
-interrupt **resume** is not yet supported here (ADR 0002 gate 2) — the caller
-surfaces a notice and the user re-runs on the default path to approve actions.
+AG-UI path additionally surfaces tool *results*). Interrupts are fully supported:
+they DISPLAY as a ``CustomEvent(on_interrupt)`` and RESUME via
+``forwarded_props.command.resume`` (ADR 0002 gate 2, resolved).
 
 Requires the ``agui`` extra::
 
@@ -42,7 +42,7 @@ def build_session_agent(graph: Any, *, name: str = "langstage-cli") -> Any:
 
 
 async def agui_stream_updates(
-    agent: Any, message: str, thread_id: str
+    agent: Any, message: str, thread_id: str, resume: Any = None
 ) -> AsyncIterator[Dict[str, Any]]:
     """Drive ``agent.run()`` in-process and yield ``print_chunk``-compatible chunks.
 
@@ -50,8 +50,18 @@ async def agui_stream_updates(
     ToolCallResult -> tool_result; CustomEvent(on_interrupt) -> interrupt;
     RunError -> error; and a one-shot MessagesSnapshot -> text when nothing streamed.
     Always terminates with a ``complete`` chunk.
+
+    When ``resume`` is provided (an interrupt is being answered), it is delivered
+    as ``forwarded_props.command.resume`` — the field the ag-ui-langgraph adapter
+    turns into LangGraph's ``Command(resume=...)`` — so the graph continues past
+    the interrupt instead of re-interrupting. Mirrors the default path's
+    ``prepare_agent_input(decisions=...)`` -> ``Command(resume={"decisions": ...})``.
     """
     from ag_ui.core.types import RunAgentInput, UserMessage
+
+    forwarded_props: Dict[str, Any] = {}
+    if resume is not None:
+        forwarded_props = {"command": {"resume": resume}}
 
     run_input = RunAgentInput(
         thread_id=thread_id,
@@ -60,7 +70,7 @@ async def agui_stream_updates(
         messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
         tools=[],
         context=[],
-        forwarded_props={},
+        forwarded_props=forwarded_props,
     )
 
     streamed_text = False

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1308,34 +1308,51 @@ async def run_single_turn_agui(
     adapter, rendering with the same ``print_chunk``. Text + tool calls/results
     reach parity with the default path (and tool *results* are also shown).
 
-    An interrupt is DISPLAYED but not resumable here (ADR 0002 gate 2): we surface
-    a notice and return, so the user re-runs on the default path to approve actions.
+    Interrupts are fully supported (ADR 0002 gate 2, resolved): an interrupt is
+    displayed, the decision is collected, and the turn resumes via the AG-UI
+    adapter's ``forwarded_props.command.resume`` — mirroring the default path's
+    interrupt loop, including the ``--no-interactive`` auto-approve behavior.
     """
     from langstage_cli.agui_stream import agui_stream_updates
 
     print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
     start_time = time.time()
-    saw_interrupt = False
-    first_chunk = True
-    spinner = Spinner("Thinking")
-    spinner.start()
-    try:
-        async for chunk in agui_stream_updates(agent, message, thread_id):
-            if first_chunk:
-                spinner.stop()
-                first_chunk = False
-            print_chunk(chunk, verbose=verbose)
-            if chunk.get("status") == "interrupt":
-                saw_interrupt = True
-    finally:
-        spinner.stop()
+    resume = None  # first pass sends the message; later passes carry the decision
 
-    if saw_interrupt:
-        print(
-            f"\n{YELLOW}⚠ The experimental --agui path can display interrupts but "
-            f"can't resume them yet (ADR 0002 gate 2).{RESET}"
-        )
-        print(f"{DIM}  Re-run without --agui to approve or edit pending actions.{RESET}")
+    while True:
+        has_interrupt = False
+        num_pending_actions = 0
+        first_chunk = True
+        spinner = Spinner("Thinking")
+        spinner.start()
+        try:
+            async for chunk in agui_stream_updates(agent, message, thread_id, resume=resume):
+                if first_chunk:
+                    spinner.stop()
+                    first_chunk = False
+                print_chunk(chunk, verbose=verbose)
+                if chunk.get("status") == "interrupt":
+                    has_interrupt = True
+                    interrupt_data = chunk.get("interrupt", {})
+                    action_requests = interrupt_data.get("action_requests", [])
+                    num_pending_actions = len(action_requests) if action_requests else 1
+        finally:
+            spinner.stop()
+
+        if has_interrupt and interactive:
+            decisions = handle_interrupt_input(num_pending_actions)
+            resume = {"decisions": decisions}
+        elif has_interrupt:
+            # --no-interactive: auto-approve and resume so the agent runs to
+            # completion (same behavior as the default path, gh #32).
+            print(
+                f"{DIM}Auto-approving {num_pending_actions} pending action(s) "
+                f"(--no-interactive){RESET}"
+            )
+            decisions = [{"type": "approve"} for _ in range(num_pending_actions)]
+            resume = {"decisions": decisions}
+        else:
+            break
 
     return time.time() - start_time
 
@@ -1566,7 +1583,7 @@ def run_conversation_loop(
     is_flag=True,
     default=False,
     help="[experimental] Stream via the in-process AG-UI adapter instead of the "
-    "built-in event parser (text + tool calls/results; interrupts display only). "
+    "built-in event parser (text, tool calls/results, and interrupts). "
     'Requires the agui extra: pip install "langstage-cli[agui]".',
 )
 @click.option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.16"
+version = "0.5.17"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_agui_stream.py
+++ b/tests/test_agui_stream.py
@@ -117,3 +117,36 @@ def test_interrupt_surfaces_as_interrupt_chunk():
     interrupts = [c for c in chunks if c.get("status") == "interrupt"]
     assert interrupts, chunks
     assert interrupts[0]["interrupt"]["action_requests"][0]["tool"] == "approve"
+
+
+def test_interrupt_resume_continues_the_graph():
+    """gate 2: resuming via forwarded_props.command.resume drives the graph past
+    the interrupt (the default path's Command(resume=...) semantics)."""
+
+    def gate(state):
+        decision = interrupt({"action_requests": [{"tool": "approve", "args": {}}]})
+        return {"messages": [AIMessage(content=f"resolved: {decision}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("gate", gate)
+    b.add_edge(START, "gate")
+    b.add_edge("gate", END)
+    agent = build_session_agent(b.compile(checkpointer=InMemorySaver()))
+
+    async def go():
+        # turn 1 -> interrupt
+        c1 = [c async for c in agui_stream_updates(agent, "go", "resume-test")]
+        assert any(c.get("status") == "interrupt" for c in c1), c1
+        # resume with a decision -> the graph must continue, not re-interrupt
+        c2 = [
+            c
+            async for c in agui_stream_updates(
+                agent, "go", "resume-test", resume={"decisions": [{"type": "accept"}]}
+            )
+        ]
+        return c2
+
+    resumed = asyncio.run(go())
+    assert not any(c.get("status") == "interrupt" for c in resumed), resumed
+    text = "".join(c["chunk"] for c in resumed if "chunk" in c)
+    assert "resolved:" in text and "accept" in text


### PR DESCRIPTION
## What

Resolves **ADR 0002 gate 2** for the cli: the `--agui` path (shipped display-only in 0.5.16) now **resumes** interrupts, so it fully supports HITL.

## The fix

The earlier spike failed to resume because it used the top-level `RunAgentInput.resume` (a typed `ResumeEntry` list). Reading the `ag-ui-langgraph` adapter showed it actually reads the resume value from **`forwarded_props.command.resume`**, which it converts to LangGraph's `Command(resume=...)`. Passing `{"decisions": [...]}` there — the exact value the default path builds via `prepare_agent_input(decisions=...)` → `Command(resume={"decisions": ...})` — drives the graph past the interrupt.

## Changes

- `agui_stream_updates(..., resume=None)` → delivers the decision as `forwarded_props.command.resume`.
- `run_single_turn_agui()` now runs the **full interrupt loop** mirroring the default sync path: display → collect decision (`handle_interrupt_input`) → resume → repeat, including the `--no-interactive` auto-approve behavior (gh #32).

## Verified

- End-to-end: an interrupting agent under `--agui --no-interactive` displays the action, auto-approves, and **continues to completion** (`⏺ done, decision={'decisions': [{'type': 'approve'}]}`).
- Test added: interrupt **resume round-trip** (graph continues, does not re-interrupt). 4 agui tests pass; ruff clean.

## Why it matters beyond the cli

The same `forwarded_props.command.resume` mechanism is what the **web board and VS Code** HITL surfaces need — gate 2 was the shared blocker for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
