### PR TITLE
refactor(agui): delegate chunk mapping to core iter_chunk_frames (ADR 0002 dedupe)

### DIFF
--- a/langstage_cli/agui_stream.py
+++ b/langstage_cli/agui_stream.py
@@ -16,8 +16,6 @@ Requires the ``agui`` extra::
     pip install "langstage-cli[agui]"
 """
 
-import json
-import uuid
 from typing import Any, AsyncIterator, Dict
 
 _IMPORT_HINT = 'the --agui path needs the agui extra: pip install "langstage-cli[agui]"'
@@ -56,57 +54,11 @@ async def agui_stream_updates(
     turns into LangGraph's ``Command(resume=...)`` — so the graph continues past
     the interrupt instead of re-interrupting. Mirrors the default path's
     ``prepare_agent_input(decisions=...)`` -> ``Command(resume={"decisions": ...})``.
+
+    The mapping itself lives in the core (``agui.iter_chunk_frames``, 0.6.17) —
+    shared with langstage-jupyter — so a rendering fix lands once.
     """
-    from ag_ui.core.types import RunAgentInput, UserMessage
+    from langgraph_stream_parser.agui import iter_chunk_frames
 
-    forwarded_props: Dict[str, Any] = {}
-    if resume is not None:
-        forwarded_props = {"command": {"resume": resume}}
-
-    run_input = RunAgentInput(
-        thread_id=thread_id,
-        run_id=str(uuid.uuid4()),
-        state={},
-        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
-        tools=[],
-        context=[],
-        forwarded_props=forwarded_props,
-    )
-
-    streamed_text = False
-    tool_buf: Dict[str, Dict[str, str]] = {}
-
-    async for ev in agent.run(run_input):
-        t = type(ev).__name__
-        if t == "TextMessageContentEvent":
-            streamed_text = True
-            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
-        elif t == "ToolCallStartEvent":
-            tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
-        elif t == "ToolCallArgsEvent":
-            tool_buf.setdefault(ev.tool_call_id, {"name": "tool", "args": ""})["args"] += ev.delta
-        elif t == "ToolCallEndEvent":
-            tc = tool_buf.pop(ev.tool_call_id, {"name": "tool", "args": ""})
-            try:
-                args = json.loads(tc["args"]) if tc["args"] else {}
-            except json.JSONDecodeError:
-                args = {"_raw": tc["args"]}
-            yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
-        elif t == "ToolCallResultEvent":
-            yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
-        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
-            payload = getattr(ev, "value", None)
-            if isinstance(payload, str):
-                try:
-                    payload = json.loads(payload)
-                except json.JSONDecodeError:
-                    payload = {"action_requests": []}
-            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
-        elif t == "MessagesSnapshotEvent" and not streamed_text:
-            for m in ev.messages:
-                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
-                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
-        elif t == "RunErrorEvent":
-            yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
-
-    yield {"status": "complete"}
+    async for frame in iter_chunk_frames(agent, message, thread_id, resume=resume):
+        yield frame

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.17"
+version = "0.5.18"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +27,7 @@ dependencies = [
     "langgraph>=0.2.0",
     # >=0.6.6 modernizes off the stale <0.5 pin and carries the dict-form-message
     # fix, so a CompiledGraph returning {"role":...,"content":...} renders (gh #-dogfood).
-    "langgraph-stream-parser>=0.6.6,<0.7",
+    "langgraph-stream-parser>=0.6.17,<0.7",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -49,7 +49,7 @@ dev = [
     "ag-ui-langgraph>=0.0.41",
     "fastapi",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.6.6,<0.7"]
+agui = ["langgraph-stream-parser[agui]>=0.6.17,<0.7"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"


### PR DESCRIPTION
`agui_stream_updates` now delegates to the core's `agui.iter_chunk_frames` (0.6.17) instead of carrying its own copy of the AG-UI→chunk-dict mapping — the byte-identical twin of langstage-jupyter's. **Behavior unchanged** (4 agui tests still pass); single source of truth so fixes land once. Core floor → `>=0.6.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)