### PR TITLE
feat!: repoint to langstage-core 1.0, AG-UI-only (ADR 0003 C2)

### DIFF
--- a/langstage_cli/__init__.py
+++ b/langstage_cli/__init__.py
@@ -1,34 +1,19 @@
 """
-langstage_cli - A Claude Code-style CLI for running LangGraph agents.
+langstage_cli - a Claude Code-style CLI for running LangGraph agents.
 
-The streaming / interrupt utilities that used to live here now come from
-``langgraph-stream-parser``. This package re-exports its dict-based convenience
-API for backward compatibility; the lower-level helpers (interrupt parsing,
-tool-call serialization, content extraction) are available from
-``langgraph_stream_parser.extractors`` if needed directly.
+Streaming runs through the in-process AG-UI adapter (``langstage-core``'s
+``agui``); the ``langstage-core`` 1.0 rename retired the old StreamParser
+convenience API. ``prepare_agent_input`` is re-exported for callers that build
+agent input directly.
 """
 
 from importlib.metadata import PackageNotFoundError, version
 
-from langgraph_stream_parser import (
-    prepare_agent_input,
-    stream_graph_updates,
-    resume_graph_from_interrupt,
-    astream_graph_updates,
-    aresume_graph_from_interrupt,
-)
+from langstage_core import prepare_agent_input
 
-# Single source of truth is the installed distribution metadata, so this can
-# never drift from pyproject's version (it was stuck at a stale "0.4.0").
 try:
     __version__ = version("langstage-cli")
 except PackageNotFoundError:  # pragma: no cover - editable/source checkout
     __version__ = "0.0.0+local"
 
-__all__ = [
-    "prepare_agent_input",
-    "stream_graph_updates",
-    "resume_graph_from_interrupt",
-    "astream_graph_updates",
-    "aresume_graph_from_interrupt",
-]
+__all__ = ["prepare_agent_input"]

--- a/langstage_cli/agui_stream.py
+++ b/langstage_cli/agui_stream.py
@@ -25,7 +25,7 @@ def ensure_agui_available() -> None:
     """Raise a clean, actionable error if the AG-UI adapter isn't installed."""
     try:
         import ag_ui_langgraph  # noqa: F401
-        from langgraph_stream_parser.agui import build_agent  # noqa: F401
+        from langstage_core.agui import build_agent  # noqa: F401
     except ImportError as e:  # pragma: no cover - exercised only without the extra
         raise RuntimeError(_IMPORT_HINT) from e
 
@@ -34,7 +34,7 @@ def build_session_agent(graph: Any, *, name: str = "langstage-cli") -> Any:
     """Wrap a compiled graph once per session (checkpointer attached by the core
     bridge), so multi-turn memory persists across turns."""
     ensure_agui_available()
-    from langgraph_stream_parser.agui import build_agent
+    from langstage_core.agui import build_agent
 
     return build_agent(graph, name=name)
 
@@ -58,7 +58,7 @@ async def agui_stream_updates(
     The mapping itself lives in the core (``agui.iter_chunk_frames``, 0.6.17) —
     shared with langstage-jupyter — so a rendering fix lands once.
     """
-    from langgraph_stream_parser.agui import iter_chunk_frames
+    from langstage_core.agui import iter_chunk_frames
 
     async for frame in iter_chunk_frames(agent, message, thread_id, resume=resume):
         yield frame

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -18,12 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
-from langgraph_stream_parser import (
-    prepare_agent_input,
-    stream_graph_updates,
-    astream_graph_updates,
-    load_agent_spec,
-)
+from langstage_core import load_agent_spec
 from langstage_cli import config as config_module
 
 # Platform-specific imports for keyboard input
@@ -467,7 +462,7 @@ def load_graph(spec: str, default_graph_name: str = "graph"):
     Load a graph from either a file path or module path.
 
     Delegates the actual import to the shared
-    ``langgraph_stream_parser.host.load_agent_spec`` loader, while preserving
+    ``langstage_core.host.load_agent_spec`` loader, while preserving
     this CLI's convenience of a bare path (no ``:name``), which defaults to
     ``default_graph_name``.
 
@@ -834,133 +829,6 @@ def _resolve_stream_mode(stream_mode: str):
     explicit single-mode power-user choices.
     """
     return ["updates", "messages"] if stream_mode == "auto" else stream_mode
-
-
-async def run_single_turn_async(
-    graph,
-    message: str,
-    config: Optional[Dict[str, Any]] = None,
-    interactive: bool = True,
-    verbose: bool = False,
-    stream_mode: str = "updates",
-) -> float:
-    """Run a single turn of an async LangGraph graph. Returns total duration in seconds."""
-    input_data = prepare_agent_input(message=message)
-    lg_stream_mode = _resolve_stream_mode(stream_mode)
-    print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
-    start_time = time.time()
-
-    while True:
-        has_interrupt = False
-        num_pending_actions = 0
-        first_chunk = True
-        spinner = Spinner("Thinking")
-        spinner.start()
-
-        try:
-            async for chunk in astream_graph_updates(
-                graph, input_data, config=config, stream_mode=lg_stream_mode
-            ):
-                # Stop spinner on first chunk
-                if first_chunk:
-                    spinner.stop()
-                    first_chunk = False
-
-                print_chunk(chunk, verbose=verbose)
-
-                if chunk.get("status") == "interrupt":
-                    has_interrupt = True
-                    # Count pending action requests
-                    interrupt_data = chunk.get("interrupt", {})
-                    action_requests = interrupt_data.get("action_requests", [])
-                    num_pending_actions = len(action_requests) if action_requests else 1
-        finally:
-            # Always stop the spinner (see sync variant) so a streaming error
-            # can't leave a daemon thread holding stdout at interpreter shutdown.
-            spinner.stop()
-
-        if has_interrupt and interactive:
-            decisions = handle_interrupt_input(num_pending_actions)
-            input_data = prepare_agent_input(decisions=decisions)
-        elif has_interrupt:
-            # --no-interactive: auto-approve every pending action and resume, so
-            # the agent runs to completion — the documented "auto-approve tool
-            # calls" behavior — instead of silently dropping the interrupt and
-            # exiting 0 with the agent's work abandoned. (gh #32)
-            print(
-                f"{DIM}Auto-approving {num_pending_actions} pending action(s) "
-                f"(--no-interactive){RESET}"
-            )
-            decisions = [{"type": "approve"} for _ in range(num_pending_actions)]
-            input_data = prepare_agent_input(decisions=decisions)
-        else:
-            break
-
-    return time.time() - start_time
-
-
-def run_single_turn_sync(
-    graph,
-    message: str,
-    config: Optional[Dict[str, Any]] = None,
-    interactive: bool = True,
-    verbose: bool = False,
-    stream_mode: str = "updates",
-) -> float:
-    """Run a single turn of a sync LangGraph graph. Returns total duration in seconds."""
-    input_data = prepare_agent_input(message=message)
-    lg_stream_mode = _resolve_stream_mode(stream_mode)
-    print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
-    start_time = time.time()
-
-    while True:
-        has_interrupt = False
-        num_pending_actions = 0
-        first_chunk = True
-        spinner = Spinner("Thinking")
-        spinner.start()
-
-        try:
-            for chunk in stream_graph_updates(
-                graph, input_data, config=config, stream_mode=lg_stream_mode
-            ):
-                # Stop spinner on first chunk
-                if first_chunk:
-                    spinner.stop()
-                    first_chunk = False
-
-                print_chunk(chunk, verbose=verbose)
-
-                if chunk.get("status") == "interrupt":
-                    has_interrupt = True
-                    # Count pending action requests
-                    interrupt_data = chunk.get("interrupt", {})
-                    action_requests = interrupt_data.get("action_requests", [])
-                    num_pending_actions = len(action_requests) if action_requests else 1
-        finally:
-            # Always stop the spinner — if the stream raises, an unstopped daemon
-            # spinner thread holds stdout at interpreter shutdown, which crashes
-            # with "Fatal Python error: _enter_buffered_busy".
-            spinner.stop()
-
-        if has_interrupt and interactive:
-            decisions = handle_interrupt_input(num_pending_actions)
-            input_data = prepare_agent_input(decisions=decisions)
-        elif has_interrupt:
-            # --no-interactive: auto-approve every pending action and resume, so
-            # the agent runs to completion — the documented "auto-approve tool
-            # calls" behavior — instead of silently dropping the interrupt and
-            # exiting 0 with the agent's work abandoned. (gh #32)
-            print(
-                f"{DIM}Auto-approving {num_pending_actions} pending action(s) "
-                f"(--no-interactive){RESET}"
-            )
-            decisions = [{"type": "approve"} for _ in range(num_pending_actions)]
-            input_data = prepare_agent_input(decisions=decisions)
-        else:
-            break
-
-    return time.time() - start_time
 
 
 def print_help():
@@ -1396,21 +1264,19 @@ def run_conversation_loop(
         "stream_mode": stream_mode,
     }
 
-    # Experimental --agui: build the in-process AG-UI agent ONCE per session
-    # (checkpointer attached by the core bridge) so multi-turn memory persists.
-    agui_agent = None
+    # Build the in-process AG-UI agent ONCE per session (checkpointer attached by
+    # the core bridge) so multi-turn memory persists. Since langstage-core 1.0 the
+    # AG-UI adapter is the only streaming path.
     thread_id = ""
-    if use_agui:
-        if isinstance(config, dict):
-            thread_id = config.get("configurable", {}).get("thread_id", "") or ""
-        from langstage_cli.agui_stream import build_session_agent
+    if isinstance(config, dict):
+        thread_id = config.get("configurable", {}).get("thread_id", "") or ""
+    from langstage_cli.agui_stream import build_session_agent
 
-        try:
-            agui_agent = build_session_agent(graph, name=agent_name)
-        except RuntimeError as e:
-            print(f"{RED}⏺ {e}{RESET}")
-            return
-        print(f"{DIM}(experimental --agui: streaming via in-process AG-UI){RESET}")
+    try:
+        agui_agent = build_session_agent(graph, name=agent_name)
+    except RuntimeError as e:
+        print(f"{RED}⏺ {e}{RESET}")
+        return
 
     # Process initial message if provided
     if initial_message:
@@ -1418,20 +1284,9 @@ def run_conversation_loop(
         print(f"{initial_message}")
         print()
 
-        if use_agui:
-            duration = asyncio.run(
-                run_single_turn_agui(agui_agent, initial_message, thread_id, interactive, verbose)
-            )
-        elif use_async:
-            duration = asyncio.run(
-                run_single_turn_async(
-                    graph, initial_message, config, interactive, verbose, stream_mode
-                )
-            )
-        else:
-            duration = run_single_turn_sync(
-                graph, initial_message, config, interactive, verbose, stream_mode
-            )
+        duration = asyncio.run(
+            run_single_turn_agui(agui_agent, initial_message, thread_id, interactive, verbose)
+        )
         print_timing(duration, verbose)
         print()
 
@@ -1499,21 +1354,10 @@ def run_conversation_loop(
 
             print()  # Space before response
 
-            # Run the agent
-            if use_agui:
-                duration = asyncio.run(
-                    run_single_turn_agui(agui_agent, user_input, thread_id, interactive, verbose)
-                )
-            elif use_async:
-                duration = asyncio.run(
-                    run_single_turn_async(
-                        graph, user_input, config, interactive, verbose, stream_mode
-                    )
-                )
-            else:
-                duration = run_single_turn_sync(
-                    graph, user_input, config, interactive, verbose, stream_mode
-                )
+            # Run the agent (AG-UI is the only streaming path since langstage-core 1.0)
+            duration = asyncio.run(
+                run_single_turn_agui(agui_agent, user_input, thread_id, interactive, verbose)
+            )
             print_timing(duration, verbose)
             print()
 
@@ -1655,7 +1499,7 @@ def main(
             print(f"{RED}⏺ Error: --demo and -a/--agent are mutually exclusive{RESET}")
             sys.exit(1)
         # The keyless echo agent shipped with the shared core.
-        agent_spec = "langgraph_stream_parser.demo.stub:graph"
+        agent_spec = "langstage_core.demo.stub:graph"
 
     # CLI flags are the highest-precedence config layer. Build the override dict
     # ONCE and use it for both --show-config and the real run, so the diagnostic

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -1,7 +1,7 @@
 """Configuration for langstage-cli.
 
 Shares the TOML loader and the ``DEEPAGENT_*`` schema with the rest of the
-deep-agent family via ``langgraph_stream_parser.host``: global
+deep-agent family via ``langstage_core.host``: global
 ``~/.deepagents/config.toml`` + project ``deepagents.toml`` (merged), then env
 vars, then CLI overrides.
 
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, List, Optional, Tuple
 
-from langgraph_stream_parser.host import HostConfig, load_toml_config
+from langstage_core.host import HostConfig, load_toml_config
 
 
 class ConfigError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.5.18"
+version = "0.6.0"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +27,7 @@ dependencies = [
     "langgraph>=0.2.0",
     # >=0.6.6 modernizes off the stale <0.5 pin and carries the dict-form-message
     # fix, so a CompiledGraph returning {"role":...,"content":...} renders (gh #-dogfood).
-    "langgraph-stream-parser>=0.6.17,<0.7",
+    "langstage-core>=1.0",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -49,7 +49,7 @@ dev = [
     "ag-ui-langgraph>=0.0.41",
     "fastapi",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.6.17,<0.7"]
+agui = ["langstage-core[agui]>=1.0"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"

--- a/tests/test_agui_stream.py
+++ b/tests/test_agui_stream.py
@@ -18,7 +18,7 @@ from langchain_core.tools import tool  # noqa: E402
 from langgraph.checkpoint.memory import InMemorySaver  # noqa: E402
 from langgraph.graph import END, START, MessagesState, StateGraph  # noqa: E402
 from langgraph.types import interrupt  # noqa: E402
-from langgraph_stream_parser import load_agent_spec  # noqa: E402
+from langstage_core import load_agent_spec  # noqa: E402
 
 from langstage_cli.agui_stream import agui_stream_updates, build_session_agent  # noqa: E402
 
@@ -32,7 +32,7 @@ def _collect(agent, msg: str) -> List[dict]:
 
 def test_text_parity_on_demo_stub():
     """The keyless echo stub round-trips through AG-UI and reflects the input."""
-    agent = build_session_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    agent = build_session_agent(load_agent_spec("langstage_core.demo.stub:graph"))
     chunks = _collect(agent, "hello agui test")
     text = "".join(c["chunk"] for c in chunks if "chunk" in c)
     assert "hello agui test" in text

--- a/tests/test_stream_mode.py
+++ b/tests/test_stream_mode.py
@@ -46,18 +46,6 @@ def test_default_auto_renders_finished_aimessage(tmp_path, monkeypatch):
     assert "FINISHED_MARKER_42" in r.output
 
 
-def test_messages_mode_alone_is_token_only(tmp_path, monkeypatch):
-    """Documents why 'auto' is the default: bare 'messages' carries only LLM
-    token streams, so a finished AIMessage yields no content there."""
-    (tmp_path / "fin_agent.py").write_text(FINISHED_AIMESSAGE_AGENT)
-    monkeypatch.chdir(tmp_path)
-    r = CliRunner().invoke(
-        main, ["-a", "fin_agent.py:graph", "--no-interactive", "--stream-mode", "messages", "ping"]
-    )
-    assert r.exit_code == 0, r.output
-    assert "FINISHED_MARKER_42" not in r.output
-
-
 def test_default_stream_mode_is_auto():
     r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,58 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "ag-ui-a2ui-toolkit"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ce/85f3960a83d962e5690bc0f27a3baf3bf1602edc2b0603085928c964ea14/ag_ui_a2ui_toolkit-0.0.4.tar.gz", hash = "sha256:172e2724e53df8173685a3fb896a6e5175eea06e1dc166c715db110ba4beba76", size = 18960, upload-time = "2026-06-17T13:34:28.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/7a/acf85b01cd996bd011b71e181fd9f3daff5396fc3b7d78ba9445bfc08ecf/ag_ui_a2ui_toolkit-0.0.4-py3-none-any.whl", hash = "sha256:236fc511e1ec2399bcda0c14a109b3fb0a0c3e3988c18ef1918745b1c1535e30", size = 21315, upload-time = "2026-06-17T13:34:29.505Z" },
+]
+
+[[package]]
+name = "ag-ui-langgraph"
+version = "0.0.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ag-ui-a2ui-toolkit" },
+    { name = "ag-ui-protocol" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d5/648338b5ff8f90c488217297a8656b6c133a251a39af2d62bada142b7819/ag_ui_langgraph-0.0.42.tar.gz", hash = "sha256:5384647b9b7b098189530c59b26741581dd009c8dfda907fbfaa9bafa8d21249", size = 330419, upload-time = "2026-06-19T15:07:01.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c0/32fea8de7ac50a90ea150f999318f4d121cd22d58e446c8fdb420fc2a11e/ag_ui_langgraph-0.0.42-py3-none-any.whl", hash = "sha256:4fd19f0da6d0e16d727ec89e99b692916cbba2b0302f96aba2497043cbfec5db", size = 37969, upload-time = "2026-06-19T15:07:00.517Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
+name = "ag-ui-protocol"
+version = "0.1.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/10/4ad299267a7d04b89935aa99eef62979758fcf95aee9f8bb5d70c35b1be1/ag_ui_protocol-0.1.19.tar.gz", hash = "sha256:43c27f60d41712dcad0e9e0a203cbdf1c8e248b22417374c5c68321c448af4ea", size = 10720, upload-time = "2026-06-02T17:26:15.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/0a/bcad8116eb058e4b4a305e3fc37ebd7efc879deeb86b854f1c5b8b6e97dd/ag_ui_protocol-0.1.19-py3-none-any.whl", hash = "sha256:898843b1410d378824da0c6a776486288b9c5828689d0bf563118868e37f390f", size = 13490, upload-time = "2026-06-02T17:26:16.313Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -193,42 +245,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deepagent-code"
-version = "0.2.0"
-source = { editable = "." }
-dependencies = [
-    { name = "click" },
-    { name = "deepagents" },
-    { name = "langgraph" },
-    { name = "langgraph-stream-parser" },
-    { name = "python-dotenv" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "black" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "click", specifier = ">=8.0.0" },
-    { name = "deepagents" },
-    { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "langgraph-stream-parser", specifier = ">=0.2,<0.3" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "python-dotenv" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "deepagents"
 version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +276,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.138.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a9/9f8f7e00195c29836e9bf58bbbaf579e29878b8a67851efff93d9b6d4eb7/fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8", size = 420423, upload-time = "2026-06-29T12:44:12.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/b3/38be2c074bdd0c986340db1d72d7b2321b805b1c5a68069aa00b5d31fd02/fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615", size = 129271, upload-time = "2026-06-29T12:44:13.905Z" },
 ]
 
 [[package]]
@@ -501,10 +533,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -513,9 +546,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/0e/664d8d81b3493e09cbab72448d2f9d693d1fa5aa2bcc488602203a9b6da0/langchain_core-1.2.7.tar.gz", hash = "sha256:e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced", size = 837039, upload-time = "2026-01-09T17:44:25.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/6f/34a9fba14d191a67f7e2ee3dbce3e9b86d2fa7310e2c7f2c713583481bd2/langchain_core-1.2.7-py3-none-any.whl", hash = "sha256:452f4fef7a3d883357b22600788d37e3d8854ef29da345b7ac7099f33c31828b", size = 490232, upload-time = "2026-01-09T17:44:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
 ]
 
 [[package]]
@@ -531,6 +564,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/85/078d5aba488a82a53b8372ac1037dee4f64b020bac69e6a07e37a5059059/langchain_google_genai-4.1.3.tar.gz", hash = "sha256:28966c8fe58c9a401fdc37aeeeb0eb51744210803838ce050f022fc53d2f994e", size = 277024, upload-time = "2026-01-05T23:29:34.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/aa/ca61dc2d202a23d7605a5c0ea24bd86a39a5c23c932a166b87c7797747c5/langchain_google_genai-4.1.3-py3-none-any.whl", hash = "sha256:5d710e2dcf449d49704bdbcd31729be90b386fa008395f9552a5c090241de1a5", size = 66262, upload-time = "2026-01-05T23:29:32.924Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]
@@ -590,15 +635,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langgraph-stream-parser"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/25/f6b22d590972b2b18963f6d0e1d7e05fdacfaa95e43edaf2715724feebb6/langgraph_stream_parser-0.2.0.tar.gz", hash = "sha256:acca25a0b87b459abb689e613a5272401e6093dadbca1e962b4f2a9ef7eafcbc", size = 214023, upload-time = "2026-06-02T12:05:58.154Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/04/8b9bd68208a71917376cdf493e8073028e4f9d2a36334dcf8c8f80237f36/langgraph_stream_parser-0.2.0-py3-none-any.whl", hash = "sha256:fcafb4dc96a115777b8035edbe6a03fa4353fdb06653e3fdc027476085c266a8", size = 69948, upload-time = "2026-06-02T12:05:57.008Z" },
-]
-
-[[package]]
 name = "langsmith"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -615,6 +651,68 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/8e/3ea7a8e9ce8c530204964207af7f7778597f5a548dc1a489c0c0940561f3/langsmith-0.6.2.tar.gz", hash = "sha256:c2efd7ed61eed3b6fdbf158ea2e9862bc2636f2edc95e90d2faad9462773d097", size = 1739277, upload-time = "2026-01-08T23:17:40.504Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/e0/9d173dd2fa7f85d9ec4989f6f5a1a057d281daa8dada0ff8db0de0cb68aa/langsmith-0.6.2-py3-none-any.whl", hash = "sha256:1ea1a591f52683a5aeebdaa2b58458d72ce9598105dd8b29e16f7373631a6434", size = 282918, upload-time = "2026-01-08T23:17:38.858Z" },
+]
+
+[[package]]
+name = "langstage-cli"
+version = "0.5.18"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "langgraph" },
+    { name = "langstage-core" },
+    { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+agui = [
+    { name = "langstage-core", extra = ["agui"] },
+]
+dev = [
+    { name = "ag-ui-langgraph" },
+    { name = "black" },
+    { name = "deepagents" },
+    { name = "fastapi" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ag-ui-langgraph", marker = "extra == 'dev'", specifier = ">=0.0.41" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.3" },
+    { name = "fastapi", marker = "extra == 'dev'" },
+    { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langstage-core", specifier = ">=1.0" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "python-dotenv" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.15" },
+]
+provides-extras = ["dev", "agui"]
+
+[[package]]
+name = "langstage-core"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/4b/768fbd9a47bb66150279c87f5ce5c9aac52f510f5ee0560cb2116fe46586/langstage_core-1.0.0.tar.gz", hash = "sha256:d713aaf0a93c7c5997a839f04358a1cab35ba8c50b70d10deb84e1e9695678ca", size = 222828, upload-time = "2026-07-02T13:41:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/49/2da5eafc600119cc4d34950068f860a80502f84e57fac63bdfc537156da6/langstage_core-1.0.0-py3-none-any.whl", hash = "sha256:8b41c9600074667ef3612fa9c92d94c6d0a2bc89c14504838bf111ab94859ff7", size = 55774, upload-time = "2026-07-02T13:41:48.866Z" },
+]
+
+[package.optional-dependencies]
+agui = [
+    { name = "ag-ui-langgraph", extra = ["fastapi"] },
+    { name = "uvicorn" },
 ]
 
 [[package]]
@@ -1164,28 +1262,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.11"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/77/9a7fe084d268f8855d493e5031ea03fa0af8cc05887f638bf1c4e3363eb8/ruff-0.14.11.tar.gz", hash = "sha256:f6dc463bfa5c07a59b1ff2c3b9767373e541346ea105503b4c0369c520a66958", size = 5993417, upload-time = "2026-01-08T19:11:58.322Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/a6/a4c40a5aaa7e331f245d2dc1ac8ece306681f52b636b40ef87c88b9f7afd/ruff-0.14.11-py3-none-linux_armv6l.whl", hash = "sha256:f6ff2d95cbd335841a7217bdfd9c1d2e44eac2c584197ab1385579d55ff8830e", size = 12951208, upload-time = "2026-01-08T19:12:09.218Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/5c/360a35cb7204b328b685d3129c08aca24765ff92b5a7efedbdd6c150d555/ruff-0.14.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f6eb5c1c8033680f4172ea9c8d3706c156223010b8b97b05e82c59bdc774ee6", size = 13330075, upload-time = "2026-01-08T19:12:02.549Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9e/0cc2f1be7a7d33cae541824cf3f95b4ff40d03557b575912b5b70273c9ec/ruff-0.14.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fc34cc896f90080fca01259f96c566f74069a04b25b6205d55379d12a6855e", size = 12257809, upload-time = "2026-01-08T19:12:00.366Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e5/5faab97c15bb75228d9f74637e775d26ac703cc2b4898564c01ab3637c02/ruff-0.14.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53386375001773ae812b43205d6064dae49ff0968774e6befe16a994fc233caa", size = 12678447, upload-time = "2026-01-08T19:12:13.899Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/33/e9767f60a2bef779fb5855cab0af76c488e0ce90f7bb7b8a45c8a2ba4178/ruff-0.14.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a697737dce1ca97a0a55b5ff0434ee7205943d4874d638fe3ae66166ff46edbe", size = 12758560, upload-time = "2026-01-08T19:11:42.55Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/84/4c6cf627a21462bb5102f7be2a320b084228ff26e105510cd2255ea868e5/ruff-0.14.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6845ca1da8ab81ab1dce755a32ad13f1db72e7fba27c486d5d90d65e04d17b8f", size = 13599296, upload-time = "2026-01-08T19:11:30.371Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e1/92b5ed7ea66d849f6157e695dc23d5d6d982bd6aa8d077895652c38a7cae/ruff-0.14.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e36ce2fd31b54065ec6f76cb08d60159e1b32bdf08507862e32f47e6dde8bcbf", size = 15048981, upload-time = "2026-01-08T19:12:04.742Z" },
-    { url = "https://files.pythonhosted.org/packages/61/df/c1bd30992615ac17c2fb64b8a7376ca22c04a70555b5d05b8f717163cf9f/ruff-0.14.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:590bcc0e2097ecf74e62a5c10a6b71f008ad82eb97b0a0079e85defe19fe74d9", size = 14633183, upload-time = "2026-01-08T19:11:40.069Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e9/fe552902f25013dd28a5428a42347d9ad20c4b534834a325a28305747d64/ruff-0.14.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53fe71125fc158210d57fe4da26e622c9c294022988d08d9347ec1cf782adafe", size = 14050453, upload-time = "2026-01-08T19:11:37.555Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/93/f36d89fa021543187f98991609ce6e47e24f35f008dfe1af01379d248a41/ruff-0.14.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a35c9da08562f1598ded8470fcfef2afb5cf881996e6c0a502ceb61f4bc9c8a3", size = 13757889, upload-time = "2026-01-08T19:12:07.094Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/9f/c7fb6ecf554f28709a6a1f2a7f74750d400979e8cd47ed29feeaa1bd4db8/ruff-0.14.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0f3727189a52179393ecf92ec7057c2210203e6af2676f08d92140d3e1ee72c1", size = 13955832, upload-time = "2026-01-08T19:11:55.064Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a0/153315310f250f76900a98278cf878c64dfb6d044e184491dd3289796734/ruff-0.14.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:eb09f849bd37147a789b85995ff734a6c4a095bed5fd1608c4f56afc3634cde2", size = 12586522, upload-time = "2026-01-08T19:11:35.356Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2b/a73a2b6e6d2df1d74bf2b78098be1572191e54bec0e59e29382d13c3adc5/ruff-0.14.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c61782543c1231bf71041461c1f28c64b961d457d0f238ac388e2ab173d7ecb7", size = 12724637, upload-time = "2026-01-08T19:11:47.796Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/41/09100590320394401cd3c48fc718a8ba71c7ddb1ffd07e0ad6576b3a3df2/ruff-0.14.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:82ff352ea68fb6766140381748e1f67f83c39860b6446966cff48a315c3e2491", size = 13145837, upload-time = "2026-01-08T19:11:32.87Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/d8/e035db859d1d3edf909381eb8ff3e89a672d6572e9454093538fe6f164b0/ruff-0.14.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:728e56879df4ca5b62a9dde2dd0eb0edda2a55160c0ea28c4025f18c03f86984", size = 13850469, upload-time = "2026-01-08T19:12:11.694Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/02/bb3ff8b6e6d02ce9e3740f4c17dfbbfb55f34c789c139e9cd91985f356c7/ruff-0.14.11-py3-none-win32.whl", hash = "sha256:337c5dd11f16ee52ae217757d9b82a26400be7efac883e9e852646f1557ed841", size = 12851094, upload-time = "2026-01-08T19:11:45.163Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f1/90ddc533918d3a2ad628bc3044cdfc094949e6d4b929220c3f0eb8a1c998/ruff-0.14.11-py3-none-win_amd64.whl", hash = "sha256:f981cea63d08456b2c070e64b79cb62f951aa1305282974d4d5216e6e0178ae6", size = 14001379, upload-time = "2026-01-08T19:11:52.591Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1c/1dbe51782c0e1e9cfce1d1004752672d2d4629ea46945d19d731ad772b3b/ruff-0.14.11-py3-none-win_arm64.whl", hash = "sha256:649fb6c9edd7f751db276ef42df1f3df41c38d67d199570ae2a7bd6cbc3590f0", size = 12938644, upload-time = "2026-01-08T19:11:50.027Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
@@ -1195,6 +1292,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -1263,6 +1373,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/22/8e3142b4baffee77ce533fe956446d3699ec42f1d5252911208cbef4501e/uuid_utils-0.13.0-pp311-pypy311_pp73-manylinux_2_24_i686.whl", hash = "sha256:aeee3bd89e8de6184a3ab778ce19f5ce9ad32849d1be549516e0ddb257562d8d", size = 359503, upload-time = "2026-01-08T15:48:06.347Z" },
     { url = "https://files.pythonhosted.org/packages/bd/1a/756f1f9e31b15019c87cd2becb1c596351c50967cd143443da38df8818d1/uuid_utils-0.13.0-pp311-pypy311_pp73-manylinux_2_24_ppc64le.whl", hash = "sha256:97985256c2e59b7caa51f5c8515f64d777328562a9c900ec65e9d627baf72737", size = 467480, upload-time = "2026-01-08T15:48:07.681Z" },
     { url = "https://files.pythonhosted.org/packages/0a/20/a6929e98d9a461ca49e96194a82a1cc3fd5420f3a2f53cbb34fca438549e/uuid_utils-0.13.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:b7ccaa20e24c5f60f41a69ef571ed820737f9b0ade4cbeef56aaa8f80f5aa475", size = 333610, upload-time = "2026-01-08T15:48:09.375Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Repoints the cli onto **langstage-core 1.0** (the renamed core) and makes the in-process AG-UI adapter the **only** streaming path.

- dep `langgraph-stream-parser<0.7` → `langstage-core>=1.0`; imports `langstage_core`.
- Deleted the StreamParser runners (`run_single_turn_sync/async`); the loop always uses the AG-UI runner.
- `--agui`/`--async`/`--stream-mode` stay accepted but are no-ops.
- `__init__` drops the retired `stream_graph_updates` re-exports; `prepare_agent_input` stays.

64 tests pass; ruff clean; `langstage-cli --demo` smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)