### PR TITLE
Move AG-UI runtime into base deps (0.6.1) — bare install can run a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.1 - 2026-07-02
+
+### Fixed
+- **Bare `pip install langstage-cli` couldn't run a turn.** 0.6.0 made AG-UI the
+  only streaming path but left the AG-UI runtime (`ag-ui-langgraph[fastapi]`) in
+  the optional `[agui]` extra, so a default install hit an ImportError on the first
+  message. The runtime is now a base dependency (via `langstage-core[agui]`); the
+  `[agui]` extra is a redundant no-op alias.
+
+## 0.6.0 - 2026-07-02
+
+### Changed
+- **AG-UI is now the CLI's only streaming path (ADR 0003).** Every turn streams
+  through `langstage-core`'s in-process AG-UI adapter; removed the
+  `stream_graph_updates` turn functions. The `--agui`/`--async`/`--stream-mode`
+  flags are accepted-and-ignored for one release.
+- **Repointed to `langstage-core` 1.0** (the rename of `langgraph-stream-parser`).
+
 ## 0.5.12 - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,9 +25,11 @@ classifiers = [
 
 dependencies = [
     "langgraph>=0.2.0",
-    # >=0.6.6 modernizes off the stale <0.5 pin and carries the dict-form-message
-    # fix, so a CompiledGraph returning {"role":...,"content":...} renders (gh #-dogfood).
-    "langstage-core>=1.0",
+    # Since core 1.0 (ADR 0003) the CLI streams every turn ONLY through the
+    # in-process AG-UI adapter — there is no built-in parser fallback — so the
+    # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
+    # is a HARD dep. A bare `pip install langstage-cli` must be able to run a turn.
+    "langstage-core[agui]>=1.0",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -49,6 +51,8 @@ dev = [
     "ag-ui-langgraph>=0.0.41",
     "fastapi",
 ]
+# Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
+# existing `pip install langstage-cli[agui]` scripts/READMEs still resolve.
 agui = ["langstage-core[agui]>=1.0"]
 
 [project.scripts]


### PR DESCRIPTION
Follow-up to 0.6.0 (the AG-UI-only repoint). 0.6.0 left the AG-UI runtime (`ag-ui-langgraph[fastapi]` + uvicorn) in the optional `[agui]` extra, so a bare `pip install langstage-cli` hit an ImportError on the first message. Since AG-UI is now the *only* streaming path, the runtime is a hard dependency — folded `langstage-core[agui]` into base deps. The `[agui]` extra is now a redundant no-op alias.

Deps-only + changelog (also backfills the skipped 0.6.0 entry). Same fix already shipped in langstage-vscode 0.5.0 / langstage-jupyter 0.6.0 / langstage 0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)