### PR TITLE
Exit non-zero on agent error; separate multi-node output (gh #47, #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.2 - 2026-07-02
+
+### Fixed
+- **A single-shot / `--no-interactive` run now exits non-zero when the agent errors
+  (gh #47).** A framed error (e.g. a `RunErrorEvent` like a recursion-limit failure)
+  was displayed but the turn still "completed", so the CLI exited 0 and a piped /
+  scripted caller couldn't tell a failed run from a success. `run_single_turn_agui`
+  now reports whether the turn errored and `main()` exits 1 on it. (A raised
+  exception already exited 1 via `main`'s handler; this covers the framed case.)
+- **Multi-node graphs no longer render as an unreadable run-on (gh #43).** Non-verbose
+  streaming printed one `⏺` marker per turn and appended every chunk, so two nodes'
+  messages ran together on one line. It now starts a fresh marker when the langgraph
+  node changes. Requires `langstage-core >= 1.0.4`, which carries the real node name
+  on each frame (it previously hardcoded `"agent"`).
+
 ## 0.6.1 - 2026-07-02
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -618,15 +618,20 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
                     print_chunk._streaming_text = True
                 print(text, end="")
             else:
-                # Print the cyan bullet ONCE at the start of a streamed AI turn,
-                # then append subsequent tokens with no marker. A token-streaming
-                # model emits one chunk per token, so prefixing the marker on
-                # every chunk jammed a `⏺` before every token. (gh #34)
-                if print_chunk._streaming_text:
-                    print(render_markdown(text), end="")
-                else:
+                # Print the cyan bullet ONCE at the start of a streamed AI turn AND
+                # again when the node changes mid-turn, then append subsequent tokens
+                # with no marker. A token-streaming model emits one chunk per token, so
+                # a per-chunk marker jammed a `⏺` before every token (gh #34); but a
+                # per-turn-only marker ran two nodes' messages together on one line with
+                # no separator (gh #43). Break + re-mark on a node change.
+                if not print_chunk._streaming_text or print_chunk._streaming_node != node:
+                    if print_chunk._streaming_text:
+                        print()  # node changed mid-turn — break before the new marker
                     print(f"{CYAN}⏺{RESET} {render_markdown(text)}", end="")
+                    print_chunk._streaming_node = node
                     print_chunk._streaming_text = True
+                else:
+                    print(render_markdown(text), end="")
 
         # Handle tool calls - green tool name
         elif "tool_calls" in chunk:
@@ -1171,8 +1176,10 @@ async def run_single_turn_agui(
     thread_id: str,
     interactive: bool = True,
     verbose: bool = False,
-) -> float:
-    """Experimental ``--agui`` path: stream a turn through the in-process AG-UI
+) -> tuple[float, bool]:
+    """Stream a turn through the in-process AG-UI adapter. Returns
+    ``(elapsed_seconds, had_error)`` — ``had_error`` is True if any frame reported
+    ``status == "error"``, so a single-shot caller can exit non-zero (gh #47).
     adapter, rendering with the same ``print_chunk``. Text + tool calls/results
     reach parity with the default path (and tool *results* are also shown).
 
@@ -1185,6 +1192,7 @@ async def run_single_turn_agui(
 
     print_chunk._streaming_text = False  # fresh marker state per turn (gh #34)
     start_time = time.time()
+    had_error = False
     resume = None  # first pass sends the message; later passes carry the decision
 
     while True:
@@ -1199,6 +1207,8 @@ async def run_single_turn_agui(
                     spinner.stop()
                     first_chunk = False
                 print_chunk(chunk, verbose=verbose)
+                if chunk.get("status") == "error":
+                    had_error = True
                 if chunk.get("status") == "interrupt":
                     has_interrupt = True
                     interrupt_data = chunk.get("interrupt", {})
@@ -1222,7 +1232,7 @@ async def run_single_turn_agui(
         else:
             break
 
-    return time.time() - start_time
+    return time.time() - start_time, had_error
 
 
 def run_conversation_loop(
@@ -1284,15 +1294,17 @@ def run_conversation_loop(
         print(f"{initial_message}")
         print()
 
-        duration = asyncio.run(
+        duration, had_error = asyncio.run(
             run_single_turn_agui(agui_agent, initial_message, thread_id, interactive, verbose)
         )
         print_timing(duration, verbose)
         print()
 
-        # Exit after single-shot execution
+        # Exit after single-shot execution. Propagate the turn's error status so
+        # main() can exit non-zero — a single-shot/piped caller must be able to tell
+        # a failed run from a success (gh #47).
         if single_shot:
-            return
+            return had_error
 
     # Main conversation loop
     while True:
@@ -1355,7 +1367,7 @@ def run_conversation_loop(
             print()  # Space before response
 
             # Run the agent (AG-UI is the only streaming path since langstage-core 1.0)
-            duration = asyncio.run(
+            duration, _ = asyncio.run(
                 run_single_turn_agui(agui_agent, user_input, thread_id, interactive, verbose)
             )
             print_timing(duration, verbose)
@@ -1622,8 +1634,10 @@ def main(
         agent_description = get_agent_description(graph)
 
         # Run the conversation loop
-        # Single-shot mode: exit after processing if message was provided via CLI
-        run_conversation_loop(
+        # Single-shot mode: exit after processing if message was provided via CLI.
+        # In single-shot mode it returns whether the agent turn errored, so a piped /
+        # scripted caller can tell a failed run from a success (gh #47).
+        turn_had_error = run_conversation_loop(
             graph=graph,
             config=config_dict,
             agent_name=agent_name,
@@ -1636,6 +1650,8 @@ def main(
             initial_message=message,
             single_shot=bool(message),
         )
+        if turn_had_error:
+            sys.exit(1)
 
     except FileNotFoundError as e:
         print(f"{RED}⏺ Error: {e}{RESET}")

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -11,7 +11,6 @@ lookups.
 """
 
 import os
-import tomllib
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,15 +24,14 @@ class ConfigError(Exception):
 
 
 def load_config(start: Optional[Path] = None) -> Tuple[dict, List[Path]]:
-    """Load global + project ``deepagents.toml``, merged (project wins).
+    """Load global + project ``langstage.toml`` (legacy ``deepagents.toml``), merged.
 
-    Delegates to the shared loader so every deep-agent tool reads the same
-    files with the same precedence. Returns ``(config, sources_used)``.
+    Delegates to the shared loader so every LangStage tool reads the same files with
+    the same precedence. Since langstage-core 1.0.3 a malformed config file is skipped
+    with a stderr notice rather than raising — a typo in a config file must not crash
+    the CLI (gh langstage-jupyter#42). Returns ``(config, sources_used)``.
     """
-    try:
-        return load_toml_config(start)
-    except tomllib.TOMLDecodeError as e:
-        raise ConfigError(f"Invalid TOML: {e}") from e
+    return load_toml_config(start)
 
 
 def get(config: dict, dotted_key: str, default: Any = None) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.1"
+version = "0.6.2"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
     # in-process AG-UI adapter — there is no built-in parser fallback — so the
     # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
     # is a HARD dep. A bare `pip install langstage-cli` must be able to run a turn.
-    "langstage-core[agui]>=1.0",
+    "langstage-core[agui]>=1.0.4",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -53,7 +53,7 @@ dev = [
 ]
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage-cli[agui]` scripts/READMEs still resolve.
-agui = ["langstage-core[agui]>=1.0"]
+agui = ["langstage-core[agui]>=1.0.4"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from langstage_cli import config
 
@@ -70,13 +69,17 @@ def test_walks_up_for_project_config(tmp_path, monkeypatch):
     assert sources == [project / "deepagents.toml"]
 
 
-def test_invalid_toml_raises(tmp_path, monkeypatch):
+def test_invalid_toml_degrades_gracefully(tmp_path, monkeypatch):
+    # Since langstage-core 1.0.3 (gh langstage-jupyter#42) a malformed config file is
+    # skipped with a stderr notice, NOT raised — a typo in a config must not crash the
+    # CLI (config resolves at import time on sibling surfaces). load_config() returns
+    # usable (empty) config instead of raising.
     home = tmp_path / "home"
     _write(home / "config.toml", "this is = not = valid toml\n")
     monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(home))
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(config.ConfigError):
-        config.load_config()
+    cfg, _sources = config.load_config()  # must NOT raise
+    assert cfg == {}  # the malformed file was skipped, no garbage loaded
 
 
 def test_get_dotted_path():

--- a/tests/test_turn_exit_and_render.py
+++ b/tests/test_turn_exit_and_render.py
@@ -1,0 +1,72 @@
+"""Regressions for gh #47 (error exit code) and gh #43 (multi-node run-on).
+
+#47 — a runtime error inside the agent used to exit 0, so a single-shot / piped
+caller couldn't tell a failed run from a success. run_single_turn_agui now reports
+whether the turn errored so main() can exit non-zero.
+
+#43 — non-verbose streaming printed one `⏺` marker per turn and appended every
+chunk, so two nodes' messages ran together on one line. It now starts a fresh
+marker on a node change (the node is carried on each chunk since langstage-core 1.0.4).
+"""
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_cli.agui_stream import build_session_agent  # noqa: E402
+from langstage_cli.cli import print_chunk, run_single_turn_agui  # noqa: E402
+
+
+async def test_turn_reports_error_frame_for_nonzero_exit(monkeypatch):
+    # gh #47: an error FRAME (e.g. a RunErrorEvent — a recursion-limit failure) is
+    # displayed but the run still "completes", so before the fix the CLI exited 0
+    # and a single-shot caller couldn't tell a failed run from a success. (A raised
+    # exception is separately caught by main() -> exit 1; this is the framed case.)
+    async def fake_stream(agent, message, thread_id, resume=None):
+        yield {"status": "streaming", "chunk": "partial output", "node": "agent"}
+        yield {"status": "error", "error": "Recursion limit of 25 reached"}
+        yield {"status": "complete"}
+
+    import langstage_cli.agui_stream as agui_mod
+
+    monkeypatch.setattr(agui_mod, "agui_stream_updates", fake_stream)
+    _elapsed, had_error = await run_single_turn_agui(object(), "hi", "t-err", interactive=False)
+    assert had_error is True
+
+
+async def test_successful_turn_reports_no_error():
+    from langstage_core import load_agent_spec
+
+    agent = build_session_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+    _elapsed, had_error = await run_single_turn_agui(agent, "hi", "t-ok", interactive=False)
+    assert had_error is False
+
+
+def test_print_chunk_breaks_on_node_change_nonverbose():
+    # gh #43: two nodes' output must not render as one run-on line.
+    print_chunk._streaming_text = False
+    print_chunk._streaming_node = None
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_chunk({"status": "streaming", "chunk": "first out", "node": "first"})
+        print_chunk({"status": "streaming", "chunk": "second out", "node": "second"})
+    out = buf.getvalue()
+    assert "first out" in out and "second out" in out
+    assert "first outsecond out" not in out  # the two nodes are separated, not a run-on
+    assert out.count("⏺") == 2  # a fresh marker per node
+
+
+def test_print_chunk_same_node_stays_on_one_marker():
+    # A token-streamed reply from ONE node keeps a single marker (gh #34 not undone).
+    print_chunk._streaming_text = False
+    print_chunk._streaming_node = None
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_chunk({"status": "streaming", "chunk": "hel", "node": "agent"})
+        print_chunk({"status": "streaming", "chunk": "lo", "node": "agent"})
+    out = buf.getvalue()
+    assert out.count("⏺") == 1


### PR DESCRIPTION
Two fixes.

**gh #47 — a runtime error inside the agent exited 0.** A framed error (e.g. a `RunErrorEvent` like a recursion-limit failure) was displayed but the turn still "completed", so a single-shot / `--no-interactive` run exited 0 and a piped/scripted caller couldn't distinguish failure from success. `run_single_turn_agui` now returns `(elapsed, had_error)` and `main()` exits 1 when the turn errored. (A *raised* exception already exited 1 via `main`'s handler; this covers the framed case.)

**gh #43 — multi-node graphs rendered as a run-on.** Non-verbose streaming printed one `⏺` marker per turn and appended every chunk, so two content-emitting nodes' messages ran together on one line. `print_chunk` now starts a fresh marker on a node change (mirroring the verbose branch). Pairs with **langstage-core 1.0.4**, which carries the real langgraph node on each frame (it previously hardcoded `"agent"`, making nodes indistinguishable).

**Verified**: single-shot on a failing agent exits 1; a two-node graph renders each node on its own line with its own marker. 4 regression tests added.

Bump `0.6.1 → 0.6.2`; core floor `>= 1.0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)