### PR TITLE
Scrub leftover deepagent-code branding; disambiguate from dcode (gh #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.3 - 2026-07-02
+
+### Changed
+- **Scrubbed the leftover `deepagent-code` branding and disambiguated from
+  LangChain's `dcode` (gh #42).** The default agent display name (used when a graph
+  exposes no name) is now `Agent` instead of the old product name `AgentCode`, the
+  `examples/agent.py` header no longer says "deepagent-code", and the README makes
+  clear `langstage-cli` is **not** LangChain's `deepagents-code` (`dcode`). The
+  deprecated `deepagent-code` package + console script still work as a back-compat
+  alias.
+
 ## 0.6.2 - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The terminal stage for your LangGraph agent.** A Claude Code-style CLI that runs *any* LangGraph `CompiledGraph` — yours, not a bundled one — with streaming, tool-call rendering, and human-in-the-loop approval.
 
-> Renamed from **deepagent-code** (the old package name now just installs this one, and the `deepagent-code` command still works).
+> Renamed from **deepagent-code** (the old package name now just installs this one, and the `deepagent-code` command still works). Not to be confused with LangChain's **`deepagents-code`** (`dcode`) — that's a separate project; `langstage-cli` is the terminal stage of the [LangStage family](#every-stage-for-your-langgraph-agent).
 
 ![langstage-cli](examples/image.png)
 

--- a/examples/agent.py
+++ b/examples/agent.py
@@ -1,5 +1,5 @@
 """
-Default agent configuration for deepagent-code.
+Default agent configuration for langstage-cli.
 
 This agent is used when no custom agent is specified. It provides basic
 conversation capabilities with filesystem access and bash command execution.

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -260,7 +260,7 @@ def print_goodbye():
 
 
 def get_agent_name(graph) -> str:
-    """Extract agent name from graph object, defaulting to 'AgentCode'."""
+    """Extract agent name from graph object, defaulting to 'Agent'."""
     # Try common attribute names for agent/graph name
     for attr in ("name", "agent_name", "_name", "__name__"):
         if hasattr(graph, attr):
@@ -272,7 +272,7 @@ def get_agent_name(graph) -> str:
         name = graph.builder.name
         if name and isinstance(name, str):
             return name
-    return "AgentCode"
+    return "Agent"
 
 
 def get_agent_description(graph) -> Optional[str]:
@@ -1238,7 +1238,7 @@ async def run_single_turn_agui(
 def run_conversation_loop(
     graph,
     config: Dict[str, Any],
-    agent_name: str = "AgentCode",
+    agent_name: str = "Agent",
     agent_description: Optional[str] = None,
     use_async: bool = False,
     use_agui: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.2"
+version = "0.6.3"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closes #42.

- Default agent display name `AgentCode` → `Agent` (shown when a loaded graph exposes no name).
- `examples/agent.py` header no longer says "deepagent-code".
- README now explicitly notes `langstage-cli` is **not** LangChain's `deepagents-code` (`dcode`).

The deprecated `deepagent_code` alias package + `deepagent-code` console script stay for back-compat (unchanged). 68 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)