### PR TITLE
feat: --verify preflights the agent with one real turn (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.5 - 2026-07-03
+
+### Added
+- **`--verify`: preflight the configured agent with one real turn (ADR 0004).**
+  `langstage-cli --verify` (with `-a`/`--demo`/`LANGSTAGE_AGENT_SPEC`) loads the
+  agent, runs ONE real turn through the shared `langstage-core` primitive
+  `core.verify()`, and exits **0** if it completed cleanly, **non-zero** otherwise —
+  a real CI gate that catches a missing key / broken tool / bad graph *before* you
+  rely on it, versus a static "it imports" check. The verdict is a single line
+  (pass on stdout, failure on stderr), and a piped `--verify` auto-quiets (no
+  spinner or "Loaded" line), so `langstage-cli --verify -a my_agent.py` scripts
+  cleanly. First surface adoption of the consolidated preflight; "healthy" now
+  means the same thing here as in the other surfaces. Requires `langstage-core>=1.0.6`.
+
 ## 0.6.4 - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,7 +167,20 @@ Options:
   --demo                          Run with the built-in keyless demo agent
   --show-config                   Print the resolved configuration and exit
   -q, --quiet                     Scriptable single-shot output: only the reply
+  --verify                        Preflight the agent (one real turn); exit 0/1
   --version                       Show the version and exit
+```
+
+### Verifying an agent (CI gate)
+
+`--verify` loads the configured agent and runs **one real turn**, exiting `0` if it
+completed cleanly and non-zero otherwise — so you can gate on it in CI before
+trusting an agent. It catches a missing key, a broken tool, or a non-runnable graph
+that a static "it imports" check would wave through (it runs the same
+`langstage-core` preflight every LangStage surface uses):
+
+```bash
+langstage-cli --verify -a my_agent.py:graph || { echo "agent broken" >&2; exit 1; }
 ```
 
 ### Scriptable output

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1514,6 +1514,15 @@ def run_conversation_loop(
     "chatter, timing, and color, and emit only the agent's reply. Auto-enabled "
     "when a single-shot run is piped (stdout is not a TTY).",
 )
+@click.option(
+    "--verify",
+    "verify_agent",
+    is_flag=True,
+    default=False,
+    help="Preflight the configured agent: run ONE real turn and exit 0 if it "
+    "completed cleanly, non-zero otherwise. Catches a missing key / broken tool "
+    "/ bad graph before you rely on it (e.g. in CI).",
+)
 def main(
     message: Optional[str],
     agent_spec: Optional[str],
@@ -1527,6 +1536,7 @@ def main(
     agui: bool,
     show_config: bool,
     quiet: bool,
+    verify_agent: bool,
 ):
     """
     Run a LangGraph agent from the command line.
@@ -1561,6 +1571,7 @@ def main(
         langstage-cli -f ./prompt.md
         langstage-cli --demo "try it with no API key"
         langstage-cli --show-config
+        langstage-cli --verify -a my_agent.py   # preflight one real turn; exit 0/1
     """
     # Windows consoles default to cp1252, where the spinner (Braille frames) and
     # status glyphs (✓ ⏺ —) raise UnicodeEncodeError — the documented
@@ -1572,16 +1583,17 @@ def main(
         except (AttributeError, ValueError):  # non-reconfigurable stream
             pass
 
-    # Scriptable single-shot output (gh #53). A single-shot run (a MESSAGE arg or
-    # -f/--file) that is piped — stdout is not a TTY — auto-enables quiet so the
-    # consumer gets only the reply; --quiet forces it even in a terminal. Color is
-    # additionally stripped whenever stdout is not a TTY, matching well-behaved CLIs.
+    # Scriptable output (gh #53). A single-shot run (a MESSAGE arg or -f/--file) or
+    # a --verify preflight that is piped — stdout is not a TTY — auto-enables quiet
+    # so the consumer gets only the reply/verdict (no spinner or "Loaded" line);
+    # --quiet forces it in a terminal. Color is additionally stripped whenever stdout
+    # is not a TTY, matching well-behaved CLIs.
     try:
         _is_tty = sys.stdout.isatty()
     except (AttributeError, ValueError):
         _is_tty = False
     global _QUIET
-    _QUIET = quiet or (bool(message or prompt_file) and not _is_tty)
+    _QUIET = quiet or ((bool(message or prompt_file) or verify_agent) and not _is_tty)
     if _QUIET or not _is_tty:
         _disable_ansi()
 
@@ -1699,6 +1711,21 @@ def main(
         if loading:
             loading.stop()
             print(f"{GREEN}✓{RESET} {DIM}Loaded {final_spec}{RESET}")
+
+        # --verify: preflight the configured agent by running ONE real turn through
+        # the shared core primitive (langstage-core >= 1.0.6), then exit on its
+        # verdict. A green here means the agent actually completed a turn — not just
+        # that it imported — so `langstage-cli --verify -a my_agent.py` is a real CI
+        # gate. Delegates to core.verify so "healthy" means the same across surfaces.
+        if verify_agent:
+            from langstage_core.agui import verify as _core_verify
+
+            result = _core_verify(graph)
+            if result.ok:
+                print(f"{GREEN}✓{RESET} agent verified: {result.reason}")
+                sys.exit(0)
+            _status(f"{RED}✗ agent verification failed: {result.reason}{RESET}")
+            sys.exit(1)
 
         # Seed LangGraph RunnableConfig from TOML [configurable] table if present
         config_dict: Dict[str, Any] = {"configurable": {}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.4"
+version = "0.6.5"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,8 @@ dependencies = [
     # in-process AG-UI adapter — there is no built-in parser fallback — so the
     # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
     # is a HARD dep. A bare `pip install langstage-cli` must be able to run a turn.
-    "langstage-core[agui]>=1.0.4",
+    # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
+    "langstage-core[agui]>=1.0.6",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -53,7 +54,7 @@ dev = [
 ]
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage-cli[agui]` scripts/READMEs still resolve.
-agui = ["langstage-core[agui]>=1.0.4"]
+agui = ["langstage-core[agui]>=1.0.6"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"

--- a/tests/test_verify_flag.py
+++ b/tests/test_verify_flag.py
@@ -1,0 +1,45 @@
+"""`--verify` preflights the configured agent with a real turn (ADR 0004 adoption).
+
+It delegates to `langstage_core.agui.verify`, so a green here means the agent
+actually completed a turn — a real CI gate — not just that it imported. Exit 0 on
+success, non-zero on failure, with the diagnostic on stderr so stdout stays clean.
+"""
+
+import textwrap
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_BROKEN_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END, MessagesState
+
+    def boom(state):
+        raise RuntimeError("tool exploded")
+
+    b = StateGraph(MessagesState)
+    b.add_node("boom", boom)
+    b.add_edge(START, "boom")
+    b.add_edge("boom", END)
+    graph = b.compile()
+    """
+)
+
+
+def test_verify_demo_passes_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--demo", "--verify"])
+    assert r.exit_code == 0, r.output
+    assert "verified" in r.output  # the pass verdict, on stdout
+    # A preflight is not a chat: no header/marker leaks.
+    assert "⏺" not in r.output and "\x1b[" not in r.output, r.output
+
+
+def test_verify_broken_agent_fails_exit_one(tmp_path, monkeypatch):
+    (tmp_path / "broken.py").write_text(_BROKEN_AGENT)
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["-a", "broken.py:graph", "--verify"])
+    assert r.exit_code == 1
+    assert r.stdout.strip() == "", r.stdout  # stdout stays clean for scripting
+    assert "verification failed" in r.stderr, r.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -687,8 +687,8 @@ requires-dist = [
     { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "fastapi", marker = "extra == 'dev'" },
     { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.4" },
-    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.4" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.6" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -699,14 +699,14 @@ provides-extras = ["dev", "agui"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.4"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b2/d974f0727717ae8d6a619fdc724cb64d79b92e334bd25333aa4b39bda1ca/langstage_core-1.0.4.tar.gz", hash = "sha256:4d7828c331804a8a62ceeeaad26c0188edbc27b8dfc0e191abf01cae175d849c", size = 222498, upload-time = "2026-07-03T01:33:03.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/cb/ad7e6df5b5a8c0058108ff8819f77b3521a898a625aebfb83b186717a4b8/langstage_core-1.0.6.tar.gz", hash = "sha256:23d5ef9671dc2aa6f0fa98128758d18cca89d46ca6c759963b49d0b2449b1c9e", size = 229186, upload-time = "2026-07-03T16:53:07.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/a2/51e0ff4f2b81540a14d211b02cc1057572173ed4bab00f0e85721657372d/langstage_core-1.0.4-py3-none-any.whl", hash = "sha256:50ada2e29d94ecf925c8f9f1798869123ee2dcf1ae4bd6689db2805b8e759d8b", size = 53468, upload-time = "2026-07-03T01:33:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/11/85810930bbc62b6e6d51f69aeb3dca88d3df5ec95da07f82d41bf61ca7a3/langstage_core-1.0.6-py3-none-any.whl", hash = "sha256:61072221d64961b03fd93a6af0dc7030bd008bc1cf30fecac74e26d135a9b443", size = 56227, upload-time = "2026-07-03T16:53:06.018Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
First surface adoption of the shared preflight from ADR 0004 (langstage-core `verify()`, new in 1.0.6).

### What
`langstage-cli --verify` (with `-a`/`--demo`/`LANGSTAGE_AGENT_SPEC`) loads the configured agent, runs **one real turn** through `langstage_core.agui.verify`, and exits **0** if it completed cleanly / **non-zero** otherwise. The verdict is a single line — pass on stdout, failure on stderr — and a piped `--verify` auto-quiets (no spinner / "Loaded" line), so it scripts cleanly:

```bash
langstage-cli --verify -a my_agent.py:graph || { echo "agent broken" >&2; exit 1; }
```

### Why
cli had **no** real-turn preflight — only static `--show-config`. `--verify` catches a missing key, a broken tool, or a non-runnable graph *before* you rely on the agent (e.g. in CI), where "it imports" would wave it through. It delegates to the shared core primitive, so "healthy" means the same thing here as in vscode `--selfcheck` and hermes `verify`.

### Tests / verification
`tests/test_verify_flag.py`: `--demo --verify` passes (exit 0, verdict on stdout, no chrome); a graph whose node raises fails (exit 1, stdout clean, "verification failed" on stderr). Verified live both directions. 77 passed, ruff + format clean. Bumps the core floor to `>=1.0.6`.

Backlog item 38 (adopt `core.verify` across surfaces) — cli is the first; web/jupyter/hermes-doctor follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)