### PR TITLE
feat: apply workspace via core.apply_workspace (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.6 - 2026-07-03
+
+### Changed
+- **Workspace root is now applied through the shared `core.apply_workspace()`
+  (ADR 0005).** Replaces the local `os.chdir` block with the one source of truth:
+  the resolved workspace is published (env + active) so the agent's tools can read
+  `core.workspace_root()`, and cli still `chdir`s into it (it's single-process) when
+  one was explicitly configured. Same observable behavior, minus the drift — plus a
+  configured workspace that doesn't exist yet is now **created** (via
+  `apply_workspace`'s `ensure()`) instead of silently ignored. Requires
+  `langstage-core>=1.0.7`.
+
 ## 0.6.5 - 2026-07-03
 
 ### Added

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
-from langstage_core import load_agent_spec
+from langstage_core import apply_workspace, load_agent_spec
 from langstage_cli import config as config_module
 
 # Platform-specific imports for keyboard input
@@ -1673,10 +1673,9 @@ def main(
             sys.exit(2)
         use_async = cfg.async_mode
         verbose = cfg.verbose
-        # Only change directory when a workspace root was actually configured.
-        workspace_root = (
-            cfg.workspace_root if cfg.sources.get("workspace_root") != "default" else None
-        )
+        # Whether a workspace root was explicitly configured (vs the default cwd);
+        # cli chdirs into it only when it was, matching prior behavior.
+        workspace_explicit = cfg.sources.get("workspace_root") != "default"
 
         # If no spec provided, try the default agent
         if not final_spec:
@@ -1696,11 +1695,12 @@ def main(
         # under workspace_root, not where the user is and put the file. (gh #30)
         final_spec = _absolutize_file_spec(final_spec)
 
-        # Change to workspace root if specified
-        if workspace_root:
-            workspace_path = Path(workspace_root).expanduser().resolve()
-            if workspace_path.exists():
-                os.chdir(workspace_path)
+        # Apply the resolved workspace as the single source of truth (ADR 0005):
+        # publish it (env + active) so the agent's tools can read workspace_root(),
+        # and chdir into it (cli is single-process) when one was explicitly
+        # configured. Runs AFTER _absolutize_file_spec so `-a my_agent.py` still
+        # resolves against the invocation cwd, not the workspace (gh #30).
+        apply_workspace(Path(cfg.workspace_root).expanduser(), chdir=workspace_explicit)
 
         # Load the graph with a spinner (both are chrome; quiet mode stays silent
         # until the reply). (gh #53)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.5"
+version = "0.6.6"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,7 +30,7 @@ dependencies = [
     # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
     # is a HARD dep. A bare `pip install langstage-cli` must be able to run a turn.
     # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
-    "langstage-core[agui]>=1.0.6",
+    "langstage-core[agui]>=1.0.7",
     "click>=8.0.0",
     "python-dotenv",
 ]
@@ -54,7 +54,7 @@ dev = [
 ]
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage-cli[agui]` scripts/READMEs still resolve.
-agui = ["langstage-core[agui]>=1.0.6"]
+agui = ["langstage-core[agui]>=1.0.7"]
 
 [project.scripts]
 langstage-cli = "langstage_cli.cli:main"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,48 @@
+"""cli applies the resolved workspace via core.apply_workspace (ADR 0005).
+
+The acceptance behavior all the workspace bugs were about: with a workspace
+configured, a turn whose agent writes a *relative* file must land that file in the
+workspace, not the launch cwd.
+"""
+
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_WRITER_AGENT = (
+    "from pathlib import Path\n"
+    "from langgraph.graph import StateGraph, START, END, MessagesState\n"
+    "from langchain_core.messages import AIMessage\n"
+    "def node(s):\n"
+    "    Path('marker.txt').write_text('hi')\n"
+    "    return {'messages': [AIMessage(content='wrote marker')]}\n"
+    "b = StateGraph(MessagesState)\n"
+    "b.add_node('n', node)\n"
+    "b.add_edge(START, 'n')\n"
+    "b.add_edge('n', END)\n"
+    "graph = b.compile()\n"
+)
+
+
+def test_configured_workspace_is_where_the_agent_writes(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    agent = tmp_path / "writer.py"
+    agent.write_text(_WRITER_AGENT)
+    # Workspace comes from the env (cli has no --workspace flag); track both names
+    # so monkeypatch restores them (apply_workspace also sets the legacy one).
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(ws))
+    monkeypatch.setenv("DEEPAGENT_WORKSPACE_ROOT", "")
+
+    origin = Path.cwd()
+    try:
+        r = CliRunner().invoke(main, ["-a", f"{agent}:graph", "go"])
+    finally:
+        os.chdir(origin)  # cli chdir'd into the workspace; restore for other tests
+
+    assert r.exit_code == 0, r.output
+    # The relative write landed in the configured workspace, not the launch cwd.
+    assert (ws / "marker.txt").read_text() == "hi"
+    assert not (origin / "marker.txt").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -687,8 +687,8 @@ requires-dist = [
     { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "fastapi", marker = "extra == 'dev'" },
     { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.6" },
-    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.6" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.7" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -699,14 +699,14 @@ provides-extras = ["dev", "agui"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.6"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/cb/ad7e6df5b5a8c0058108ff8819f77b3521a898a625aebfb83b186717a4b8/langstage_core-1.0.6.tar.gz", hash = "sha256:23d5ef9671dc2aa6f0fa98128758d18cca89d46ca6c759963b49d0b2449b1c9e", size = 229186, upload-time = "2026-07-03T16:53:07.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7a/e9414ca7fa3857945de02743c7b42bc391dd723c9d36f52d6f552a37fe63/langstage_core-1.0.7.tar.gz", hash = "sha256:b9218b3585aba51630b531fa2c66038e279df9abfad3736bfc6071f708fc27cd", size = 235044, upload-time = "2026-07-03T21:38:11.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/11/85810930bbc62b6e6d51f69aeb3dca88d3df5ec95da07f82d41bf61ca7a3/langstage_core-1.0.6-py3-none-any.whl", hash = "sha256:61072221d64961b03fd93a6af0dc7030bd008bc1cf30fecac74e26d135a9b443", size = 56227, upload-time = "2026-07-03T16:53:06.018Z" },
+    { url = "https://files.pythonhosted.org/packages/41/00/a59d85d92d4bd9ae5d165ede92dbd6793aeae4a883f1cf1fc0398b0e2d09/langstage_core-1.0.7-py3-none-any.whl", hash = "sha256:9aa0b854f7d82da2273ede090786bada0d3587f2adeadf95dc90152d7af59b2b", size = 57344, upload-time = "2026-07-03T21:38:10.819Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
First surface migration for ADR 0005 (workspace application in core, shipped in `langstage-core` 1.0.7).

### What
Replaces cli's local `os.chdir` block with `core.apply_workspace(cfg.workspace_root, chdir=<explicit>)`: the resolved workspace is published as the single source of truth (env + active) so the agent's tools can read `core.workspace_root()`, and cli still `chdir`s into it (it's single-process) when a workspace was explicitly configured.

### Behavior
Same as before, minus the drift — with one improvement: a configured workspace that doesn't exist yet is now **created** (`apply_workspace` calls `ensure()`) instead of the old silent skip-if-missing.

### Test (the ADR 0005 acceptance)
`tests/test_workspace.py`: with a workspace configured, a turn whose agent writes a **relative** file lands that file in the workspace — not the launch cwd. This is the single behavior all the workspace bugs were about. 78 passed. Bumps the core floor to `>=1.0.7`.

Migration order: **cli** (this) → vscode → hermes → jupyter → web (last, gated on the #44 split-brain regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)