### PR TITLE
fix: forward the [configurable] TOML table to the graph (gh #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.7 - 2026-07-04
+
+### Fixed
+- **The `langstage.toml` `[configurable]` table now reaches the graph (gh #57).**
+  `/config` and `--show-config` advertise that `[configurable]` seeds LangGraph's
+  `RunnableConfig.configurable`, but the AG-UI streaming path forwarded only
+  `thread_id` — every other key (model name, feature flags, API config, …) was
+  silently dropped, so a node's `config["configurable"]` saw `None`. The session
+  agent is now built with the resolved configurable (`build_session_agent(config=…)`
+  → `build_agent(config=…)`), so those keys reach the graph on every turn.
+
 ## 0.6.6 - 2026-07-03
 
 ### Changed

--- a/langstage_cli/agui_stream.py
+++ b/langstage_cli/agui_stream.py
@@ -30,13 +30,18 @@ def ensure_agui_available() -> None:
         raise RuntimeError(_IMPORT_HINT) from e
 
 
-def build_session_agent(graph: Any, *, name: str = "langstage-cli") -> Any:
+def build_session_agent(graph: Any, *, name: str = "langstage-cli", config: Any = None) -> Any:
     """Wrap a compiled graph once per session (checkpointer attached by the core
-    bridge), so multi-turn memory persists across turns."""
+    bridge), so multi-turn memory persists across turns.
+
+    ``config`` (a ``RunnableConfig``, e.g. ``{"configurable": {...}}`` seeded from
+    ``langstage.toml``'s ``[configurable]`` table) is forwarded to the graph on
+    every turn, so keys beyond ``thread_id`` actually reach the agent. (gh #57)
+    """
     ensure_agui_available()
     from langstage_core.agui import build_agent
 
-    return build_agent(graph, name=name)
+    return build_agent(graph, name=name, config=config)
 
 
 async def agui_stream_updates(

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1328,12 +1328,21 @@ def run_conversation_loop(
     # the core bridge) so multi-turn memory persists. Since langstage-core 1.0 the
     # AG-UI adapter is the only streaming path.
     thread_id = ""
+    configurable: Dict[str, Any] = {}
     if isinstance(config, dict):
-        thread_id = config.get("configurable", {}).get("thread_id", "") or ""
+        configurable = dict(config.get("configurable", {}))
+        thread_id = configurable.get("thread_id", "") or ""
     from langstage_cli.agui_stream import build_session_agent
 
+    # Forward the resolved `[configurable]` table (minus thread_id, which the
+    # adapter sets per-run) to the graph, so keys beyond thread_id — the documented
+    # way to parameterize an agent — actually reach it instead of being silently
+    # dropped while /config advertises them. (gh #57)
+    configurable.pop("thread_id", None)
+    session_config = {"configurable": configurable} if configurable else None
+
     try:
-        agui_agent = build_session_agent(graph, name=agent_name)
+        agui_agent = build_session_agent(graph, name=agent_name, config=session_config)
     except RuntimeError as e:
         _status(f"{RED}⏺ {e}{RESET}")
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.6"
+version = "0.6.7"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_configurable.py
+++ b/tests/test_configurable.py
@@ -1,0 +1,37 @@
+"""The langstage.toml [configurable] table reaches the graph (gh #57).
+
+`/config` and `--show-config` advertise that `[configurable]` seeds LangGraph's
+`RunnableConfig.configurable`, but the AG-UI streaming path used to forward only
+`thread_id` — every other key was silently dropped. The session agent now carries
+the resolved configurable, so a node's `config["configurable"]` sees it.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_CFG_AGENT = (
+    "from langgraph.graph import StateGraph, START, END\n"
+    "from langgraph.graph.message import MessagesState\n"
+    "from langchain_core.messages import AIMessage\n"
+    "def respond(state, config):\n"
+    "    c = (config or {}).get('configurable', {})\n"
+    "    return {'messages': [AIMessage(content='custom_key=' + str(c.get('custom_key')))]}\n"
+    "g = StateGraph(MessagesState)\n"
+    "g.add_node('respond', respond)\n"
+    "g.add_edge(START, 'respond')\n"
+    "g.add_edge('respond', END)\n"
+    "graph = g.compile()\n"
+)
+
+
+def test_configurable_toml_reaches_the_graph(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "langstage.toml").write_text('[configurable]\ncustom_key = "from-toml"\n')
+    agent = tmp_path / "cfg_agent.py"
+    agent.write_text(_CFG_AGENT)
+
+    r = CliRunner().invoke(main, ["-a", f"{agent}:graph", "hi"])
+    assert r.exit_code == 0, r.output
+    # The node saw the [configurable] value, not None.
+    assert "custom_key=from-toml" in r.output, r.output

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #57.

The README, CHANGELOG, and the live `/config` command all advertise that `langstage.toml`'s `[configurable]` table "seeds LangGraph `RunnableConfig.configurable`." In reality only `thread_id` reached the graph — every other key (model name, feature flags, API config, …) was **silently dropped**, so a node's `config["configurable"]` saw `None` while `--show-config` cheerfully displayed the keys as active.

The AG-UI path never forwarded the configurable: `build_session_agent` → `build_agent(graph, name=…)` passed no config, and `iter_chunk_frames` only carries `thread_id`. Now the session agent is built with the resolved configurable — `build_session_agent(config={"configurable": …})` → `build_agent(config=…)` — which the adapter merges into the graph's `RunnableConfig` on every turn (verified: a node sees both the run's `thread_id` and the TOML keys).

`tests/test_configurable.py`: a `langstage.toml` `[configurable]` value reaches a node's `config["configurable"]` end-to-end. 79 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)