### PR TITLE
docs: refresh README header image to the LangStage name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 > Renamed from **deepagent-code** (the old package name now just installs this one, and the `deepagent-code` command still works). Not to be confused with LangChain's **`deepagents-code`** (`dcode`) — that's a separate project; `langstage-cli` is the terminal stage of the [LangStage family](#every-stage-for-your-langgraph-agent).
 
-![langstage-cli](examples/image.png)
+<p align="center">
+  <img src="assets/header.svg" alt="langstage-cli — the terminal stage for your LangGraph agent" width="100%" />
+</p>
 
 ## Every stage for your LangGraph agent
 

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langstage-cli — the terminal stage for your LangGraph agent">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B1221"/>
+      <stop offset="1" stop-color="#0C1A1A"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#34D6C8"/>
+      <stop offset="1" stop-color="#7C5CFF"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.82" cy="0.15" r="0.6">
+      <stop offset="0" stop-color="#34D6C8" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#34D6C8" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="340" rx="20" fill="url(#bg)"/>
+  <rect width="1280" height="340" rx="20" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1278" height="338" rx="19" fill="none" stroke="#1F3340" stroke-width="1.5"/>
+
+  <!-- ===== left: identity ===== -->
+  <g transform="translate(72,66)">
+    <rect width="104" height="34" rx="17" fill="#0F2A2A" stroke="url(#accent)" stroke-width="1.5"/>
+    <circle cx="22" cy="17" r="5" fill="url(#accent)"/>
+    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#9FE9DF">terminal</text>
+  </g>
+
+  <text x="70" y="178" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="60" font-weight="700" fill="#F2F6FC" letter-spacing="-1">langstage-<tspan fill="url(#accent)">cli</tspan></text>
+
+  <text x="72" y="224" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#9DB2C8">The terminal stage for your LangGraph agent &#8212;</text>
+  <text x="72" y="254" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#9DB2C8">a Claude Code-style REPL for any CompiledGraph.</text>
+
+  <g font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="13" fill="#6F8A86">
+    <text x="72" y="300">chat</text>
+    <text x="124" y="300" fill="#345050">&#8226;</text>
+    <text x="144" y="300">tool calls</text>
+    <text x="228" y="300" fill="#345050">&#8226;</text>
+    <text x="248" y="300">interrupts</text>
+    <text x="340" y="300" fill="#345050">&#8226;</text>
+    <text x="360" y="300">--demo</text>
+  </g>
+
+  <!-- ===== right: terminal mock ===== -->
+  <g transform="translate(788,74)">
+    <rect width="424" height="192" rx="12" fill="#08120F" stroke="#1F3340" stroke-width="1.5"/>
+    <rect width="424" height="28" rx="12" fill="#0E1C18"/>
+    <rect y="16" width="424" height="12" fill="#0E1C18"/>
+    <circle cx="20" cy="14" r="4" fill="#E06C75"/>
+    <circle cx="36" cy="14" r="4" fill="#E5C07B"/>
+    <circle cx="52" cy="14" r="4" fill="#98C379"/>
+    <text x="404" y="18" text-anchor="end" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#4A6560">langstage-cli</text>
+    <g font-family="'SF Mono','Consolas',monospace" font-size="12" transform="translate(18,52)">
+      <text x="0" y="0" fill="#7FE3D6">$ <tspan fill="#C7D6E6">langstage-cli --demo "summarize notes.md"</tspan></text>
+      <text x="0" y="30" fill="#7C5CFF">&#9679;</text>
+      <text x="18" y="30" fill="#A6AECB">reading notes.md &#8230;</text>
+      <text x="0" y="54" fill="#34D6C8">&#9679;</text>
+      <text x="18" y="54" fill="#8FC4FF">read_file</text>
+      <text x="94" y="54" fill="#4A6560">notes.md &#8594; 3 items</text>
+      <text x="0" y="82" fill="#7FE3D6">&#8635;</text>
+      <text x="18" y="82" fill="#E6EDF5">Your notes cover LangGraph 1.2, durable</text>
+      <text x="18" y="100" fill="#E6EDF5">execution, and AG-UI streaming.</text>
+      <rect x="278" y="90" width="8" height="14" fill="#34D6C8" opacity="0.9"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The README header still showed an old name. Updated the SVG header (family style, correct name/API). Found by fresh-user dogfood.