### PR TITLE
fix: strip prompt color after ansi is disabled

### DIFF
--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -173,12 +173,13 @@ def rl_wrap(code: str) -> str:
     return code
 
 
-def make_prompt(text: str = "❯", color: str = BRIGHT_BLUE) -> str:
+def make_prompt(text: str = "❯", color: str | None = None) -> str:
     """Create a prompt string with proper readline escaping for ANSI codes.
 
     This prevents line wrapping issues on Windows and other terminals.
     """
-    return f"{rl_wrap(BOLD)}{rl_wrap(color)}{text}{rl_wrap(RESET)} "
+    prompt_color = BRIGHT_BLUE if color is None else color
+    return f"{rl_wrap(BOLD)}{rl_wrap(prompt_color)}{text}{rl_wrap(RESET)} "
 
 
 def register_command(

--- a/tests/test_quiet_output.py
+++ b/tests/test_quiet_output.py
@@ -36,6 +36,14 @@ def test_quiet_flag_forces_clean_output(tmp_path, monkeypatch):
     assert "\x1b[" not in r.output and "⏺" not in r.output, r.output
 
 
+def test_make_prompt_uses_disabled_color_globals_after_ansi_is_disabled():
+    c._disable_ansi()
+
+    prompt = c.make_prompt()
+
+    assert "\x1b[" not in prompt, repr(prompt)
+
+
 def test_errors_go_to_stderr_not_stdout(tmp_path, monkeypatch):
     # A failed single-shot run must keep stdout clean so a scripted caller can
     # consume the (empty) reply and read the diagnostic off stderr / the exit code.


### PR DESCRIPTION
## Summary

- resolve the default prompt color at call time so `_disable_ansi()` also strips `make_prompt()`'s default color
- add a regression test for the disabled-ANSI prompt path

Fixes #60.

## Verification

- Red before fix: `uv run --extra dev python -m pytest tests/test_quiet_output.py -k 'make_prompt_uses_disabled_color_globals' -q` failed with a stray `\x1b[94m` in `make_prompt()` output
- `uv run --extra dev python -m pytest tests/test_quiet_output.py -k 'make_prompt_uses_disabled_color_globals' -q`
- `uv run --extra dev python -m pytest tests/test_quiet_output.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev python -m pytest -ra`
- `git diff --check`

Additional check: `uv run --extra dev mypy .` currently fails on existing repository baseline issues, mostly untyped third-party imports and pre-existing CLI typing errors outside this change.