### PR TITLE
fix: deprecate the dead --stream-mode no-op instead of advertising it (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.9 - 2026-07-06
+
+### Changed
+- **`--stream-mode` is deprecated — it was a no-op advertised as a feature (gh #62).**
+  `--stream-mode {auto,updates,messages}`, `LANGSTAGE_STREAM_MODE`, and `[ui] stream_mode`
+  claimed three streaming behaviors, but since the AG-UI streaming migration all three
+  render identically — the setting had zero effect (the `_resolve_stream_mode` mapper was
+  never called). Rather than keep advertising a dead knob, it is now: hidden from `--help`,
+  omitted from `--show-config`, no longer resolved from the env var / TOML key, and
+  accepted-and-ignored on the CLI (so an existing `--stream-mode X` invocation doesn't
+  hard-error) with a one-line deprecation notice. No rendering behavior changes.
+
 ## 0.6.8 - 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -111,9 +111,6 @@ langstage-cli
 
 # Working directory
 export LANGSTAGE_WORKSPACE_ROOT="/path/to/workspace"
-
-# Stream mode (updates or messages)
-export LANGSTAGE_STREAM_MODE="updates"
 ```
 
 ## Configuration Files
@@ -142,7 +139,6 @@ root = "."
 [ui]
 verbose = true
 async_mode = false
-stream_mode = "auto"   # auto | updates | messages
 
 [configurable]
 # seeds LangGraph RunnableConfig.configurable
@@ -163,8 +159,6 @@ Options:
   -f, --file PATH                 Read message from a file (any extension)
   --interactive/--no-interactive  Handle interrupts (default: interactive)
   --async-mode/--sync-mode        Async streaming (default: sync)
-  --stream-mode [auto|updates|messages]
-                                  Stream mode (default: auto)
   -v, --verbose                   Verbose output
   --demo                          Run with the built-in keyless demo agent
   --show-config                   Print the resolved configuration and exit

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -76,11 +76,12 @@ def _status(msg: str) -> None:
     print(msg, file=sys.stderr if _QUIET else sys.stdout)
 
 
-# Inherited HostConfig keys the terminal CLI never reads: it starts no server
-# (host/port/debug are inert) and the header box uses the loaded graph's name,
-# not `title`. `--show-config` / `/config` omit these so the diagnostic only
-# advertises knobs this surface actually honors. (gh #36)
-_INERT_KEYS = ["host", "port", "debug", "title"]
+# Keys the terminal CLI never honors, so `--show-config` / `/config` omit them and
+# the diagnostic only advertises knobs that actually do something. The inherited
+# HostConfig server keys — it starts no server (host/port/debug are inert) and the
+# header box uses the loaded graph's name, not `title` (gh #36) — plus `stream_mode`,
+# which has had no effect since the AG-UI streaming migration (gh #62).
+_INERT_KEYS = ["host", "port", "debug", "title", "stream_mode"]
 
 # Spinner frames for thinking animation
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
@@ -865,20 +866,6 @@ def handle_interrupt_input(num_actions: int = 1) -> List[Dict[str, Any]]:
         sys.exit(0)
 
 
-def _resolve_stream_mode(stream_mode: str):
-    """Map the user-facing stream mode to what LangGraph actually streams.
-
-    'auto' = dual-channel ``["updates", "messages"]``: the parser renders LLM
-    tokens live when the agent streams them, and falls back to the finished
-    message content otherwise — so a node that returns a complete (non-token-
-    streamed) ``AIMessage`` still renders instead of an empty turn. (Bare
-    'messages' only carries LLM token streams, which is exactly why it was a
-    silent-blank trap — gh #-dogfood.) 'updates'/'messages' pass through as the
-    explicit single-mode power-user choices.
-    """
-    return ["updates", "messages"] if stream_mode == "auto" else stream_mode
-
-
 def print_help():
     """Print formatted help information."""
     print(f"\n{BOLD}{BRIGHT_CYAN}Commands{RESET}")
@@ -980,14 +967,12 @@ def cmd_status(args: str, context: Dict[str, Any]) -> Optional[str]:
     agent_name = context.get("agent_name", "Unknown")
     verbose = context.get("verbose", False)
     use_async = context.get("use_async", False)
-    stream_mode = context.get("stream_mode", "updates")
 
     print(f"\n{BOLD}{BRIGHT_CYAN}Session Status{RESET}")
     print(f"{DIM}{'─' * 30}{RESET}")
     print(f"  {DIM}Agent:{RESET}       {agent_name}")
     print(f"  {DIM}Thread ID:{RESET}   {thread_id[:8]}...")
     print(f"  {DIM}Mode:{RESET}        {'async' if use_async else 'sync'}")
-    print(f"  {DIM}Stream:{RESET}      {stream_mode}")
     print(f"  {DIM}Verbose:{RESET}     {'on' if verbose else 'off'}")
     print(f"  {DIM}CWD:{RESET}         {os.getcwd()}")
     print()
@@ -1483,9 +1468,11 @@ def run_conversation_loop(
 @click.option(
     "--stream-mode",
     type=click.Choice(["auto", "updates", "messages"]),
-    help="Stream mode: 'auto' (default; token streaming when the agent emits "
-    "tokens, full-message fallback otherwise), 'updates' (whole-message), or "
-    "'messages' (token-level only — a finished AIMessage renders nothing here).",
+    # DEPRECATED (gh #62): a no-op since the AG-UI streaming migration — all three
+    # modes render identically. Kept hidden + accepted so existing `--stream-mode X`
+    # invocations don't hard-error; a one-line notice fires when it is passed.
+    hidden=True,
+    help="(deprecated: no effect since the AG-UI streaming migration).",
 )
 @click.option(
     "--verbose",
@@ -1566,7 +1553,6 @@ def main(
     \b
     - LANGSTAGE_AGENT_SPEC: Agent location (same formats as above).
     - LANGSTAGE_WORKSPACE_ROOT: Working directory for the agent
-    - LANGSTAGE_STREAM_MODE: Stream mode for LangGraph (auto, updates, or messages)
 
     Reads ~/.langstage/config.toml (global) and langstage.toml (project,
     walks up from cwd). Precedence: CLI args > env vars > project TOML >
@@ -1629,6 +1615,14 @@ def main(
         "verbose": True if verbose else None,
     }
 
+    # --stream-mode is deprecated and inert since the AG-UI streaming migration
+    # (gh #62): accepted so scripts don't break, but say so once when it's passed.
+    if stream_mode is not None:
+        _status(
+            f"{DIM}⏺ Note: --stream-mode is deprecated and has no effect "
+            f"(streaming is uniform since the AG-UI migration).{RESET}"
+        )
+
     if show_config:
         # See _INERT_KEYS: hide the server/web keys this surface ignores. (gh #36)
         print(
@@ -1671,16 +1665,10 @@ def main(
         )
         final_spec = cfg.agent_spec
         final_graph_name_default = cfg.graph_name
+        # stream_mode is deprecated and inert (gh #62) — it only ever comes from the
+        # accepted-and-ignored flag now (env/TOML no longer resolve it), so there is
+        # nothing to validate; it changes no rendering.
         final_stream_mode = cfg.stream_mode
-        # The CLI's render path only supports 'updates' / 'messages'. Reject anything
-        # else (e.g. LANGSTAGE_STREAM_MODE=values, which bypasses the flag's Choice)
-        # with a clean error instead of a fatal crash deep in the stream worker.
-        if final_stream_mode not in ("auto", "updates", "messages"):
-            _status(
-                f"{RED}⏺ Error: unsupported stream mode {final_stream_mode!r} "
-                f"(use 'auto', 'updates', or 'messages')"
-            )
-            sys.exit(2)
         use_async = cfg.async_mode
         verbose = cfg.verbose
         # Whether a workspace root was explicitly configured (vs the default cwd);

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -84,16 +84,18 @@ class CodeConfig(HostConfig):
     resolver); the even-older ``DEEPAGENT_SPEC`` alias is reconciled below.
     """
 
+    # stream_mode is retained as an inert field (default only) so existing code and
+    # `--stream-mode` overrides don't break, but it is DEPRECATED: it has no effect
+    # since the AG-UI streaming migration (all three modes render identically). It is
+    # no longer resolved from LANGSTAGE_STREAM_MODE / [ui] stream_mode, and is omitted
+    # from `--show-config`. (gh #62)
     stream_mode: str = "auto"
     graph_name: str = "graph"
     verbose: bool = False
     async_mode: bool = False
 
-    _ENV: ClassVar[dict] = {
-        "stream_mode": ("LANGSTAGE_STREAM_MODE", str),
-    }
+    _ENV: ClassVar[dict] = {}
     _TOML: ClassVar[dict] = {
-        "stream_mode": "ui.stream_mode",
         "graph_name": "agent.graph_name",
         "verbose": "ui.verbose",
         "async_mode": "ui.async_mode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.8"
+version = "0.6.9"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -21,7 +21,9 @@ def test_help_leads_with_canonical_names():
     # canonical LANGSTAGE_* / langstage.toml are present...
     assert "LANGSTAGE_AGENT_SPEC" in out
     assert "LANGSTAGE_WORKSPACE_ROOT" in out
-    assert "LANGSTAGE_STREAM_MODE" in out
     assert "langstage.toml" in out
+    # ...and the deprecated, no-op stream-mode knob is no longer advertised (gh #62)
+    assert "LANGSTAGE_STREAM_MODE" not in out
+    assert "--stream-mode" not in out
     # ...and the legacy names are no longer presented as the only config vocab
     assert "DEEPAGENT_AGENT_SPEC" not in out

--- a/tests/test_codeconfig.py
+++ b/tests/test_codeconfig.py
@@ -28,24 +28,26 @@ def test_defaults(isolated, tmp_path):
     assert cfg.agent_spec is None
 
 
-def test_env_stream_mode(isolated, tmp_path):
-    cfg = CodeConfig.resolve(env={"DEEPAGENT_STREAM_MODE": "values"}, toml_start=tmp_path)
-    assert cfg.stream_mode == "values"
-    assert cfg.sources["stream_mode"] == "env:DEEPAGENT_STREAM_MODE"
+def test_stream_mode_env_and_toml_are_deprecated_and_ignored(isolated, tmp_path):
+    # gh #62: stream_mode has no effect since the AG-UI migration, so it is no longer
+    # resolved from LANGSTAGE_STREAM_MODE / [ui] stream_mode — both are now ignored and
+    # the field stays at its default.
+    _toml(tmp_path, '[ui]\nstream_mode = "messages"\n')
+    cfg = CodeConfig.resolve(env={"LANGSTAGE_STREAM_MODE": "updates"}, toml_start=tmp_path)
+    assert cfg.stream_mode == "auto"  # default, neither env nor TOML applied
+    assert cfg.sources["stream_mode"] == "default"
 
 
 def test_toml_keys(isolated, tmp_path):
     _toml(
         tmp_path,
-        '[agent]\nspec = "a.py:g"\ngraph_name = "myg"\n'
-        '[ui]\nverbose = true\nasync_mode = true\nstream_mode = "values"\n',
+        '[agent]\nspec = "a.py:g"\ngraph_name = "myg"\n[ui]\nverbose = true\nasync_mode = true\n',
     )
     cfg = CodeConfig.resolve(env={}, toml_start=tmp_path)
     assert cfg.agent_spec == "a.py:g"
     assert cfg.graph_name == "myg"
     assert cfg.verbose is True
     assert cfg.async_mode is True
-    assert cfg.stream_mode == "values"
 
 
 def test_deepagent_spec_alias_is_deprecated(isolated, tmp_path):
@@ -75,5 +77,6 @@ def test_overrides_win(isolated, tmp_path):
 def test_describe_lists_var_names(isolated, tmp_path):
     text = CodeConfig.resolve(env={}, toml_start=tmp_path).describe()
     assert "DEEPAGENT_AGENT_SPEC" in text
-    assert "DEEPAGENT_STREAM_MODE" in text
-    assert "stream_mode" in text
+    # A field with a live TOML key is listed with its key (stream_mode's env/TOML
+    # were removed as a deprecated no-op — gh #62 — so it's no longer var-backed).
+    assert "graph_name" in text

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -14,13 +14,10 @@ from langstage_cli.cli import main
 
 def test_show_config_reflects_cli_flags():
     with CliRunner().isolated_filesystem():  # no stray toml
-        r = CliRunner().invoke(
-            main, ["-a", "fromcli.py:graph", "-v", "--stream-mode", "messages", "--show-config"]
-        )
+        r = CliRunner().invoke(main, ["-a", "fromcli.py:graph", "-v", "--show-config"])
     assert r.exit_code == 0, r.output
     # CLI-set values appear with the [override] source, not [default].
     assert re.search(r"agent_spec\s*=\s*fromcli\.py:graph\s*\[override\]", r.output), r.output
-    assert re.search(r"stream_mode\s*=\s*messages\s*\[override\]", r.output), r.output
     assert re.search(r"verbose\s*=\s*True\s*\[override\]", r.output), r.output
 
 
@@ -49,15 +46,15 @@ def test_show_config_without_flags_still_reports_env():
 
 def test_show_config_omits_server_only_keys():
     """The terminal CLI starts no server and titles the header from the graph
-    name, so host/port/debug/title are inert and must not be advertised. (gh #36)"""
+    name, so host/port/debug/title are inert and must not be advertised (gh #36).
+    stream_mode is likewise omitted — it's a deprecated no-op (gh #62)."""
     with CliRunner().isolated_filesystem():
         r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output
-    for key in ("host", "port", "debug", "title"):
+    for key in ("host", "port", "debug", "title", "stream_mode"):
         assert not re.search(rf"^\s*{key}\s*=", r.output, re.MULTILINE), f"{key} should be omitted"
     # ...but keys the CLI actually honors are still shown.
     assert re.search(r"^\s*agent_spec\s*=", r.output, re.MULTILINE), r.output
-    assert re.search(r"^\s*stream_mode\s*=", r.output, re.MULTILINE), r.output
 
 
 def test_show_config_title_env_not_advertised_as_effective():

--- a/tests/test_stream_mode.py
+++ b/tests/test_stream_mode.py
@@ -1,15 +1,14 @@
-"""--stream-mode validation + the 'auto' default (gh #-dogfood).
+"""--stream-mode is deprecated and inert (gh #62).
 
-`values` was advertised but unsupported by the CLI's render path; passing it
-crashed with a fatal interpreter-shutdown error (a ValueError surfaced while the
-spinner daemon thread held stdout). Now: the flag is a Choice {auto,updates,
-messages}, and the resolved value (incl. LANGSTAGE_STREAM_MODE, which bypasses
-the flag) is validated up front with a clean error.
+`--stream-mode {auto,updates,messages}` (and `LANGSTAGE_STREAM_MODE` / `[ui]
+stream_mode`) was advertised as three streaming behaviors, but since the AG-UI
+streaming migration all three render identically — the setting has no effect. The
+dead knob is now: hidden from `--help`, omitted from `--show-config`, no longer
+resolved from env / TOML, and accepted-and-ignored on the CLI (so existing
+`--stream-mode X` invocations don't hard-error) with a one-line deprecation notice.
 
-Separately, single 'messages' mode only carries LLM *token* streams, so a node
-that returns a finished (non-token-streamed) AIMessage rendered an empty turn.
-The default is now 'auto' (dual updates+messages) so that agent shape — the one
-the README's own "Creating Your Own Agent" example produces — still renders.
+The unrelated "a finished AIMessage still renders" behavior (the reason the old
+default was 'auto') is intrinsic to the AG-UI path now and is kept as a regression.
 """
 
 import textwrap
@@ -18,8 +17,7 @@ from click.testing import CliRunner
 
 from langstage_cli.cli import main
 
-# A graph whose node returns a *finished* AIMessage (no token streaming) — the
-# shape that was a silent blank turn under bare 'messages'.
+# A graph whose node returns a *finished* AIMessage (no token streaming).
 FINISHED_AIMESSAGE_AGENT = textwrap.dedent(
     """
     from langchain_core.messages import AIMessage
@@ -37,8 +35,8 @@ FINISHED_AIMESSAGE_AGENT = textwrap.dedent(
 )
 
 
-def test_default_auto_renders_finished_aimessage(tmp_path, monkeypatch):
-    """Regression: the default mode must render a finished AIMessage's content."""
+def test_finished_aimessage_still_renders(tmp_path, monkeypatch):
+    """Regression: a finished (non-token-streamed) AIMessage's content must render."""
     (tmp_path / "fin_agent.py").write_text(FINISHED_AIMESSAGE_AGENT)
     monkeypatch.chdir(tmp_path)
     r = CliRunner().invoke(main, ["-a", "fin_agent.py:graph", "--no-interactive", "ping"])
@@ -46,31 +44,28 @@ def test_default_auto_renders_finished_aimessage(tmp_path, monkeypatch):
     assert "FINISHED_MARKER_42" in r.output
 
 
-def test_default_stream_mode_is_auto():
+def test_stream_mode_is_omitted_from_show_config():
+    # gh #62: the deprecated no-op knob is no longer advertised in --show-config.
     r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output
-    assert "auto" in r.output
+    assert "stream_mode" not in r.output
 
 
-def test_stream_mode_values_flag_rejected_cleanly():
-    r = CliRunner().invoke(main, ["--demo", "--no-interactive", "--stream-mode", "values", "hi"])
-    assert r.exit_code != 0
-    assert "values" in r.output
-    assert "Fatal" not in r.output  # no interpreter-shutdown crash
-
-
-def test_stream_mode_messages_flag_accepted():
-    # A valid mode must still be accepted by the Choice (parses, doesn't error on the flag).
-    r = CliRunner().invoke(main, ["--stream-mode", "messages", "--show-config"])
+def test_stream_mode_flag_is_accepted_and_ignored_with_a_notice():
+    # An existing `--stream-mode X` invocation must not hard-error; it is accepted,
+    # ignored, and prints a one-line deprecation notice.
+    r = CliRunner().invoke(main, ["--demo", "--no-interactive", "--stream-mode", "messages", "hi"])
     assert r.exit_code == 0, r.output
-    assert "messages" in r.output
+    assert "deprecated" in r.output.lower()
 
 
-def test_stream_mode_values_via_env_rejected():
+def test_stream_mode_env_is_ignored_not_rejected():
+    # LANGSTAGE_STREAM_MODE used to be validated (and an unsupported value exited 2).
+    # It is now simply ignored — a run proceeds normally regardless of its value.
     r = CliRunner().invoke(
         main,
         ["--demo", "--no-interactive", "hi"],
         env={"LANGSTAGE_STREAM_MODE": "values"},
     )
-    assert r.exit_code == 2, r.output
-    assert "unsupported stream mode" in r.output.lower()
+    assert r.exit_code == 0, r.output
+    assert "unsupported stream mode" not in r.output.lower()


### PR DESCRIPTION
Closes #62 (nightly dogfood).

`--stream-mode {auto,updates,messages}`, `LANGSTAGE_STREAM_MODE`, and `[ui] stream_mode`
were advertised in the README, `--help`, and `--show-config` as three distinct streaming
behaviors — but since the AG-UI streaming migration all three produce byte-identical
output. The mapper (`_resolve_stream_mode`) was defined but **never called**; nothing
threads a stream mode into `iter_chunk_frames`.

Since the AG-UI path is intentionally uniform, the honest fix is to stop advertising a
dead knob rather than build a new streaming mode:
- delete the dead `_resolve_stream_mode`;
- hide `--stream-mode` from `--help` and omit `stream_mode` from `--show-config`;
- stop resolving it from `LANGSTAGE_STREAM_MODE` / `[ui] stream_mode`;
- keep the flag **accepted-and-ignored** (so an existing `--stream-mode X` invocation
  doesn't hard-error) with a one-line deprecation notice;
- remove it from the README.

No rendering behavior changes (all modes already rendered identically). Tests updated to
pin the new behavior (flag accepted + notice, env/TOML ignored, omitted from show-config).
Ships as **0.6.9**.