### PR TITLE
fix: interactive /config reports the true workspace_root source (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.10 - 2026-07-07
+
+### Fixed
+- **The interactive `/config` command now reports the true source of `workspace_root`,
+  matching `--show-config` (gh #64).** `/config` re-resolved the config at display time —
+  but by then startup had already called `apply_workspace()`, which self-publishes
+  `LANGSTAGE_WORKSPACE_ROOT` into the process environment (ADR 0005). So `/config` saw the
+  tool's own published var and reported `workspace_root`'s source as
+  `[env:LANGSTAGE_WORKSPACE_ROOT]` (and swapped the value for an absolute path) even when the
+  user never set it — the exact opposite of the provenance the command exists to show.
+  `/config` now reuses the config diagnostic snapshotted at startup (before the self-publish),
+  so it agrees with `--show-config`.
+
 ## 0.6.9 - 2026-07-06
 
 ### Changed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1002,14 +1002,17 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
             print(f"  {DIM}TOML sources:{RESET} {DIM}(none — using defaults){RESET}")
 
         # Full resolved view: each value, where it came from, and the env var
-        # / TOML key that sets it.
-        from langstage_cli.config import CodeConfig
+        # / TOML key that sets it. Prefer the snapshot captured at startup (before
+        # apply_workspace self-published LANGSTAGE_WORKSPACE_ROOT), so workspace_root's
+        # source is reported truthfully and /config agrees with --show-config (gh #64).
+        # Fall back to a fresh resolve only if the snapshot is somehow absent.
+        report = config.get("_resolved_config_report")
+        if report is None:
+            from langstage_cli.config import CodeConfig
 
-        # Omit the inherited server/web keys the terminal CLI never honors: it
-        # starts no server (host/port/debug inert) and the header uses the graph
-        # name, not `title`. Advertising them with source attribution is the
-        # "advertised != honored" trap. (gh #36)
-        for line in CodeConfig.resolve().describe(omit_keys=_INERT_KEYS).splitlines():
+            # Omit the inherited server/web keys the terminal CLI never honors (gh #36).
+            report = CodeConfig.resolve().describe(omit_keys=_INERT_KEYS)
+        for line in report.splitlines():
             print(f"  {line}")
 
         configurable = config.get("configurable", {})
@@ -1663,6 +1666,13 @@ def main(
             toml_start=Path.cwd(),
             overrides=cli_overrides,
         )
+        # Snapshot the resolved-config diagnostic NOW, before apply_workspace() below
+        # self-publishes LANGSTAGE_WORKSPACE_ROOT into os.environ (ADR 0005). The
+        # interactive /config used to re-resolve at display time, see the tool's own
+        # published var, and misreport workspace_root's source as [env:...] — diverging
+        # from --show-config (which runs before apply_workspace). Reuse this snapshot so
+        # /config shows the true provenance. (gh #64)
+        resolved_config_report = cfg.describe(omit_keys=_INERT_KEYS)
         final_spec = cfg.agent_spec
         final_graph_name_default = cfg.graph_name
         # stream_mode is deprecated and inert (gh #62) — it only ever comes from the
@@ -1735,6 +1745,9 @@ def main(
 
         # Expose TOML sources to slash commands via the config dict
         config_dict["_toml_sources"] = [str(p) for p in toml_sources]
+        # The resolved-config diagnostic snapshotted before apply_workspace, so /config
+        # reports the true source of workspace_root instead of the self-published env (gh #64).
+        config_dict["_resolved_config_report"] = resolved_config_report
 
         # Extract agent name and description from graph object
         agent_name = get_agent_name(graph)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.9"
+version = "0.6.10"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1,0 +1,40 @@
+"""Interactive `/config` reports the true config source, matching `--show-config` (gh #64).
+
+`/config` used to re-resolve `CodeConfig` at display time — but by then the startup path
+had already called `apply_workspace()`, which self-publishes `LANGSTAGE_WORKSPACE_ROOT`
+into `os.environ` (ADR 0005). The re-resolve saw the tool's own published var and reported
+`workspace_root`'s source as `[env:LANGSTAGE_WORKSPACE_ROOT]` even when the user never set
+it — diverging from `--show-config` (which runs before `apply_workspace`). `/config` now
+reuses the report snapshotted at startup, before the self-publish.
+"""
+
+from langstage_cli.cli import cmd_config
+
+
+def test_config_uses_startup_snapshot_not_a_reresolve(monkeypatch, capsys):
+    # Reproduce the trigger: apply_workspace has self-published the workspace env.
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", "/abs/self/published/ws")
+    monkeypatch.setenv("DEEPAGENT_WORKSPACE_ROOT", "/abs/self/published/ws")
+
+    # The snapshot captured at startup (before the self-publish) shows the true source.
+    snapshot = (
+        "agent_spec       = a.py:graph  [override]\n"
+        "workspace_root   = .           [default]   (env: LANGSTAGE_WORKSPACE_ROOT, toml: workspace.root)"
+    )
+    ctx = {
+        "config": {
+            "_resolved_config_report": snapshot,
+            "_toml_sources": [],
+            "configurable": {},
+        }
+    }
+
+    cmd_config("", ctx)
+    out = capsys.readouterr().out
+
+    # /config prints the snapshot's true provenance...
+    assert "workspace_root" in out
+    assert "[default]" in out
+    # ...and does NOT misreport the self-published env var as the source (the #64 bug).
+    assert "[env:LANGSTAGE_WORKSPACE_ROOT]" not in out
+    assert "/abs/self/published/ws" not in out


### PR DESCRIPTION
Closes #64 (nightly dogfood).

The interactive `/config` command and `langstage-cli --show-config` are both documented as
showing "the resolved configuration" with source attribution — but they **disagreed on
`workspace_root`**. `/config` always reported `[env:LANGSTAGE_WORKSPACE_ROOT]` (and swapped
the configured value for an absolute path), even when the user never set that env var.

**Root cause:** `--show-config` runs and exits *before* the startup path calls
`apply_workspace()`, which by design self-publishes the resolved workspace into the process
environment (`os.environ["LANGSTAGE_WORKSPACE_ROOT"] = <abs>`, ADR 0005). The interactive
`/config` handler then re-resolved `CodeConfig` at display time, saw the CLI's own published
var, and reported the env as the source — so the diagnostic whose whole job is provenance
reported the tool's internal plumbing as user configuration.

**Fix:** snapshot the resolved-config diagnostic at startup, *before* `apply_workspace`, and
have `/config` reuse it (fresh-resolve only as a fallback). `/config` now agrees with
`--show-config` — verified against both the TOML-set and pristine-default cases in the issue.
Ships as **0.6.10**.