### PR TITLE
fix: --show-config shows the [configurable] table, matching /config (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.11 - 2026-07-08
+
+### Fixed
+- **`--show-config` now shows the `[configurable]` table, matching interactive `/config`
+  (gh #66).** The `[configurable]` TOML table is honored at runtime (it reaches the graph's
+  `config["configurable"]`, gh #57) and `/config` displays it, but `--show-config` omitted
+  the section entirely — so a user parameterizing their agent via `[configurable]` (model
+  name, temperature, feature flags) and running `--show-config` to confirm it took effect
+  saw nothing. Both views now render the table through a shared helper, so they stay in sync.
+
 ## 0.6.10 - 2026-07-07
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -979,6 +979,20 @@ def cmd_status(args: str, context: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _print_configurable(configurable: dict) -> None:
+    """Render the LangGraph ``[configurable]`` table. Shared by ``/config`` and
+    ``--show-config`` so the two "show the resolved config" views format it identically
+    and neither omits a section the other shows (gh #66)."""
+    if not configurable:
+        return
+    print(f"  {DIM}LangGraph configurable:{RESET}")
+    for k, v in configurable.items():
+        v_str = str(v)
+        if len(v_str) > 50:
+            v_str = v_str[:50] + "..."
+        print(f"    {CYAN}{k}:{RESET} {v_str}")
+
+
 @register_command(
     name="config",
     description="Show or set configuration",
@@ -1015,14 +1029,7 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
         for line in report.splitlines():
             print(f"  {line}")
 
-        configurable = config.get("configurable", {})
-        if configurable:
-            print(f"  {DIM}LangGraph configurable:{RESET}")
-            for k, v in configurable.items():
-                v_str = str(v)
-                if len(v_str) > 50:
-                    v_str = v_str[:50] + "..."
-                print(f"    {CYAN}{k}:{RESET} {v_str}")
+        _print_configurable(config.get("configurable", {}))
         print()
     else:
         parts = args.split(maxsplit=1)
@@ -1633,6 +1640,12 @@ def main(
                 toml_start=Path.cwd(), overrides=cli_overrides
             ).describe(omit_keys=_INERT_KEYS)
         )
+        # Also show the [configurable] table — it IS honored (reaches the graph's
+        # config["configurable"], gh #57) and /config displays it, so --show-config must
+        # too, or the two "resolved config" views disagree (gh #66).
+        _toml, _ = config_module.load_config()
+        configurable = config_module.get(_toml, "configurable")
+        _print_configurable(configurable if isinstance(configurable, dict) else {})
         return
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.10"
+version = "0.6.11"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -44,6 +44,20 @@ def test_show_config_without_flags_still_reports_env():
     assert re.search(r"agent_spec\s*=\s*fromenv\.py:graph\s*\[env:", r.output), r.output
 
 
+def test_show_config_includes_the_configurable_table(tmp_path, monkeypatch):
+    # gh #66: the [configurable] table is honored (reaches the graph) and shown by
+    # interactive /config, but --show-config omitted it — the two views disagreed.
+    (tmp_path / "langstage.toml").write_text(
+        '[agent]\nspec = "agent.py:graph"\n[configurable]\nmodel_name = "gpt-4o-mini"\ntemperature = "0.2"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    assert "LangGraph configurable:" in r.output
+    assert "model_name: gpt-4o-mini" in r.output
+    assert "temperature: 0.2" in r.output
+
+
 def test_show_config_omits_server_only_keys():
     """The terminal CLI starts no server and titles the header from the graph
     name, so host/port/debug/title are inert and must not be advertised (gh #36).


### PR DESCRIPTION
Closes #66 (nightly dogfood). Continues the `/config` ↔ `--show-config` parity work (#64, #36).

The `[configurable]` TOML table is **honored** at runtime (since #57 it reaches the graph's
`config["configurable"]`) and interactive `/config` prints a `LangGraph configurable:`
section for it — but `--show-config` omitted the section entirely. So a user who
parameterizes their agent via `[configurable]` (model name, temperature, feature flags) and
runs `langstage-cli --show-config` to confirm it took effect saw nothing about it, while the
exact same info showed in `/config`.

**Fix:** both views now render the table through a shared `_print_configurable` helper, so
they format identically and neither omits a section the other shows. `--show-config` loads
the resolved `[configurable]` and prints it under the config dump.

Regression test asserts `--show-config` includes the table. Ships as **0.6.11**.