### PR TITLE
refactor: route both config views through one describe() + parity test (config-diagnostic consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.6.11 - 2026-07-08
+## 0.6.12 - 2026-07-08
+
+### Changed
+- **`--show-config` and interactive `/config` now render the identical diagnostic, and a
+  parity test locks it (config-diagnostic consolidation).** Both views were assembled from
+  pieces (`describe()` + a separately-rendered `[configurable]` table) that could drift —
+  the seam behind #64 and #66. Both now go through the single `describe(configurable=…)`
+  renderer in **langstage-core 1.0.14** (now the minimum pin); the per-surface
+  `_print_configurable` bolt-on is gone, and a test asserts the two views can't diverge.
 
 ### Fixed
 - **`--show-config` now shows the `[configurable]` table, matching interactive `/config`

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -979,20 +979,6 @@ def cmd_status(args: str, context: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _print_configurable(configurable: dict) -> None:
-    """Render the LangGraph ``[configurable]`` table. Shared by ``/config`` and
-    ``--show-config`` so the two "show the resolved config" views format it identically
-    and neither omits a section the other shows (gh #66)."""
-    if not configurable:
-        return
-    print(f"  {DIM}LangGraph configurable:{RESET}")
-    for k, v in configurable.items():
-        v_str = str(v)
-        if len(v_str) > 50:
-            v_str = v_str[:50] + "..."
-        print(f"    {CYAN}{k}:{RESET} {v_str}")
-
-
 @register_command(
     name="config",
     description="Show or set configuration",
@@ -1015,21 +1001,21 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
         else:
             print(f"  {DIM}TOML sources:{RESET} {DIM}(none — using defaults){RESET}")
 
-        # Full resolved view: each value, where it came from, and the env var
-        # / TOML key that sets it. Prefer the snapshot captured at startup (before
-        # apply_workspace self-published LANGSTAGE_WORKSPACE_ROOT), so workspace_root's
-        # source is reported truthfully and /config agrees with --show-config (gh #64).
+        # Full resolved view — the COMPLETE describe() diagnostic (fields + source +
+        # env/TOML keys + the [configurable] table). Prefer the snapshot captured at
+        # startup (before apply_workspace self-published LANGSTAGE_WORKSPACE_ROOT), so
+        # workspace_root's source is truthful and /config renders byte-for-byte what
+        # --show-config prints — both go through the one describe() (gh #64, #66).
         # Fall back to a fresh resolve only if the snapshot is somehow absent.
         report = config.get("_resolved_config_report")
         if report is None:
             from langstage_cli.config import CodeConfig
 
-            # Omit the inherited server/web keys the terminal CLI never honors (gh #36).
-            report = CodeConfig.resolve().describe(omit_keys=_INERT_KEYS)
+            report = CodeConfig.resolve().describe(
+                omit_keys=_INERT_KEYS, configurable=config.get("configurable") or None
+            )
         for line in report.splitlines():
             print(f"  {line}")
-
-        _print_configurable(config.get("configurable", {}))
         print()
     else:
         parts = args.split(maxsplit=1)
@@ -1634,18 +1620,19 @@ def main(
         )
 
     if show_config:
-        # See _INERT_KEYS: hide the server/web keys this surface ignores. (gh #36)
+        # The COMPLETE diagnostic — fields (server/web keys this surface ignores omitted,
+        # gh #36) + the honored [configurable] table (gh #57/#66) — comes from the one
+        # describe() renderer, so --show-config and /config can't disagree by construction.
+        _toml, _ = config_module.load_config()
+        _configurable = config_module.get(_toml, "configurable")
         print(
             config_module.CodeConfig.resolve(
                 toml_start=Path.cwd(), overrides=cli_overrides
-            ).describe(omit_keys=_INERT_KEYS)
+            ).describe(
+                omit_keys=_INERT_KEYS,
+                configurable=_configurable if isinstance(_configurable, dict) else None,
+            )
         )
-        # Also show the [configurable] table — it IS honored (reaches the graph's
-        # config["configurable"], gh #57) and /config displays it, so --show-config must
-        # too, or the two "resolved config" views disagree (gh #66).
-        _toml, _ = config_module.load_config()
-        configurable = config_module.get(_toml, "configurable")
-        _print_configurable(configurable if isinstance(configurable, dict) else {})
         return
 
     try:
@@ -1685,7 +1672,11 @@ def main(
         # published var, and misreport workspace_root's source as [env:...] — diverging
         # from --show-config (which runs before apply_workspace). Reuse this snapshot so
         # /config shows the true provenance. (gh #64)
-        resolved_config_report = cfg.describe(omit_keys=_INERT_KEYS)
+        _snap_configurable = config_module.get(toml_config, "configurable")
+        resolved_config_report = cfg.describe(
+            omit_keys=_INERT_KEYS,
+            configurable=_snap_configurable if isinstance(_snap_configurable, dict) else None,
+        )
         final_spec = cfg.agent_spec
         final_graph_name_default = cfg.graph_name
         # stream_mode is deprecated and inert (gh #62) — it only ever comes from the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.11"
+version = "0.6.12"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,7 +30,8 @@ dependencies = [
     # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
     # is a HARD dep. A bare `pip install langstage-cli` must be able to run a turn.
     # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
-    "langstage-core[agui]>=1.0.7",
+    # >=1.0.14 for describe(configurable=) — the single complete config diagnostic.
+    "langstage-core[agui]>=1.0.14",
     "click>=8.0.0",
     "python-dotenv",
 ]

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -44,6 +44,27 @@ def test_show_config_without_flags_still_reports_env():
     assert re.search(r"agent_spec\s*=\s*fromenv\.py:graph\s*\[env:", r.output), r.output
 
 
+def test_show_config_and_slash_config_render_the_same_diagnostic(tmp_path, monkeypatch):
+    # Consolidation guard (gh #64/#66 class): `--show-config` and interactive `/config`
+    # both render the ONE describe() diagnostic (fields + sources + the [configurable]
+    # table), so they can't drift. Lock it — every resolved line from --show-config must
+    # also appear in /config (both driven with the same --demo flag so the agent matches).
+    (tmp_path / "langstage.toml").write_text(
+        '[configurable]\nmodel_name = "gpt-4o-mini"\ntemperature = "0.2"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    show = CliRunner().invoke(main, ["--show-config", "--demo"]).output
+    slash = CliRunner().invoke(main, ["--demo"], input="/config\n/quit\n").output
+    slash_lines = {ln.strip() for ln in slash.splitlines()}
+    for ln in show.splitlines():
+        s = ln.strip()
+        if not s or s.startswith("⏺"):  # skip blanks / status (⏺) notices
+            continue
+        assert s in slash_lines, f"/config is missing a --show-config line: {s!r}"
+    # the [configurable] table (the #66 seam) is present in both.
+    assert "model_name: gpt-4o-mini" in show and "model_name: gpt-4o-mini" in slash
+
+
 def test_show_config_includes_the_configurable_table(tmp_path, monkeypatch):
     # gh #66: the [configurable] table is honored (reaches the graph) and shown by
     # interactive /config, but --show-config omitted it — the two views disagreed.

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.7"
+version = "0.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -687,7 +687,7 @@ requires-dist = [
     { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "fastapi", marker = "extra == 'dev'" },
     { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.7" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.14" },
     { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -699,14 +699,14 @@ provides-extras = ["dev", "agui"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.7"
+version = "1.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/7a/e9414ca7fa3857945de02743c7b42bc391dd723c9d36f52d6f552a37fe63/langstage_core-1.0.7.tar.gz", hash = "sha256:b9218b3585aba51630b531fa2c66038e279df9abfad3736bfc6071f708fc27cd", size = 235044, upload-time = "2026-07-03T21:38:11.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/30/fbdb059f95d45f1e01b7531c62f01bc9d1f9b99f1fe85a46577fecf949db/langstage_core-1.0.14.tar.gz", hash = "sha256:f8f12d4e7184b3ceefb9aefd360dc987c3521a898f507ee15713d3d90eb03c14", size = 240445, upload-time = "2026-07-08T14:40:41.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/00/a59d85d92d4bd9ae5d165ede92dbd6793aeae4a883f1cf1fc0398b0e2d09/langstage_core-1.0.7-py3-none-any.whl", hash = "sha256:9aa0b854f7d82da2273ede090786bada0d3587f2adeadf95dc90152d7af59b2b", size = 57344, upload-time = "2026-07-03T21:38:10.819Z" },
+    { url = "https://files.pythonhosted.org/packages/09/44/2e4c6f7f80ed7fdf322e669cba83b9afeb467e7eb69cdf9d298c335f79fd/langstage_core-1.0.14-py3-none-any.whl", hash = "sha256:236da4a2414d4c3b3b8811c1ca93e0e3a9fc4480b1d9a5b611b5e4d2e651b461", size = 60305, upload-time = "2026-07-08T14:40:42.067Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Part of the **config-diagnostic consolidation** — the proactive pass to stop the recurring
"config diagnostic is wrong/inconsistent" class (#55/#57/#61/#64/#66) instead of fixing it
one nightly issue at a time.

`--show-config` and interactive `/config` were each assembled from pieces (`describe()` base
dump **plus** a separately-rendered `[configurable]` table via `_print_configurable`) that
could drift — the exact seam behind #64 and #66. Both now render through the single
`describe(configurable=…)` renderer in **langstage-core 1.0.14** (now the minimum pin):
- delete the `_print_configurable` bolt-on;
- `--show-config` and the `/config` startup snapshot both call `describe(omit_keys, configurable)`;
- a **parity test** asserts every resolved line from `--show-config` also appears in `/config`,
  so the two can't diverge again (this is the regression guard that ends the class for cli).

Full suite 82 passed. Ships as **0.6.12**.