### PR TITLE
Show the tool name in the HITL approval prompt (gh #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.13 - 2026-07-09
+
+### Fixed
+- **The HITL approval prompt always showed `1. unknown` instead of the tool name (gh #69).**
+  The interrupt renderer read `action.get("tool")`, but a HumanInterrupt `action_request`
+  keys the tool name under `action` (the deepagents/langchain convention), so the lookup
+  always missed. That's safety-relevant — the operator couldn't see what they were about to
+  approve. Now reads `action.get("action")`, falling back to `"tool"` (for agents on the
+  older key) then `"unknown"`. Mirrors the langstage-vscode #44 fix.
+
 ## 0.6.12 - 2026-07-08
 
 ### Changed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -700,7 +700,11 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
         print(f"\n{YELLOW}⚠ Action Required{RESET}")
         if action_requests:
             for i, action in enumerate(action_requests):
-                tool = action.get("tool", "unknown")
+                # The HumanInterrupt action_request keys the tool name under "action"
+                # (deepagents/langchain convention); a bare `.get("tool")` always missed
+                # and rendered "unknown" (gh #69). Fall back to "tool" for any agent that
+                # uses the older key, then to "unknown". Mirrors the vscode #44 fix.
+                tool = action.get("action") or action.get("tool") or "unknown"
                 args_preview = get_tool_arg_preview(action.get("args", {}))
                 print(f"  {DIM}{i + 1}. {tool}{RESET}")
                 if args_preview:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.12"
+version = "0.6.13"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_turn_exit_and_render.py
+++ b/tests/test_turn_exit_and_render.py
@@ -83,7 +83,9 @@ def test_print_chunk_interrupt_shows_the_tool_name():
         print_chunk(
             {
                 "status": "interrupt",
-                "interrupt": {"action_requests": [{"action": "write_file", "args": {"path": "notes.md"}}]},
+                "interrupt": {
+                    "action_requests": [{"action": "write_file", "args": {"path": "notes.md"}}]
+                },
             }
         )
     out = buf.getvalue()

--- a/tests/test_turn_exit_and_render.py
+++ b/tests/test_turn_exit_and_render.py
@@ -70,3 +70,39 @@ def test_print_chunk_same_node_stays_on_one_marker():
         print_chunk({"status": "streaming", "chunk": "lo", "node": "agent"})
     out = buf.getvalue()
     assert out.count("⏺") == 1
+
+
+def test_print_chunk_interrupt_shows_the_tool_name():
+    # gh #69: the HITL approval prompt read `action.get("tool")`, but the HumanInterrupt
+    # action_request keys the tool name under "action" (deepagents/langchain convention),
+    # so every prompt rendered "1. unknown" — a safety-relevant blind spot (the operator
+    # can't see what they're approving). Render must surface the real tool name.
+    print_chunk._streaming_text = False
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_chunk(
+            {
+                "status": "interrupt",
+                "interrupt": {"action_requests": [{"action": "write_file", "args": {"path": "notes.md"}}]},
+            }
+        )
+    out = buf.getvalue()
+    assert "write_file" in out
+    assert "unknown" not in out
+
+
+def test_print_chunk_interrupt_falls_back_to_legacy_tool_key():
+    # Robustness: an agent that still emits the older "tool" key must not regress to
+    # "unknown" (the fix reads "action" first, then "tool", then "unknown").
+    print_chunk._streaming_text = False
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_chunk(
+            {
+                "status": "interrupt",
+                "interrupt": {"action_requests": [{"tool": "legacy_tool", "args": {}}]},
+            }
+        )
+    out = buf.getvalue()
+    assert "legacy_tool" in out
+    assert "unknown" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.11"
+version = "0.6.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

The HITL approval prompt always rendered `1. unknown` instead of the tool the agent wants to run.

```
⚠ Action Required
  1. unknown          # ← should be e.g. `write_file`
```

The interrupt renderer read `action.get("tool")`, but a HumanInterrupt `action_request` keys the tool name under **`action`** (the deepagents/langchain convention that langstage-core's `_normalize_interrupt` preserves), so the lookup always missed.

This is **safety-relevant**: the whole point of the HITL gate is that the operator sees *what* they're approving. `unknown` defeats it.

## Fix

```python
tool = action.get("action") or action.get("tool") or "unknown"
```

Reads the canonical `action` key first, falls back to `tool` for any agent still on the older key, then `unknown`. Mirrors the langstage-vscode #44 fix (`first.action ?? first.tool ?? …`).

## Tests

`tests/test_turn_exit_and_render.py`:
- interrupt frame with an `action` key renders the real tool name and never `unknown`,
- legacy `tool` key still renders (no regression to `unknown`).

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)