### PR TITLE
Floor terminal width so the header box never collapses (gh #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.14 - 2026-07-10
+
+### Fixed
+- **The header box collapsed to a bare `╭╮`/`╰╯` under a pty that reports 0 columns (gh
+  #71).** `get_terminal_width()` guarded `OSError` but not the case where
+  `os.get_terminal_size()` succeeds and reports `columns == 0` — which a pty forked without
+  an initialized window size (pexpect/expect automation, some CI pseudo-ttys, editor
+  terminals, process supervisors) really does. `min(0, 100) == 0` made the box borders
+  (`"─" * (width - 2)`) vanish while content rows overflowed. Width is now floored at 40
+  (`min(max(cols, 40), 100)`), so the banner always renders.
+
 ## 0.6.13 - 2026-07-09
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -250,11 +250,18 @@ class Spinner:
 
 
 def get_terminal_width() -> int:
-    """Get terminal width, capped at 100 for readability."""
+    """Get terminal width, floored at a sane minimum and capped at 100 for readability.
+
+    A pty forked without an initialized window size (pexpect/expect automation, some CI
+    pseudo-ttys, editor terminals, process supervisors) reports ``columns == 0`` WITHOUT
+    raising ``OSError`` — so the old `min(cols, 100)` returned 0, and the header box's
+    borders (`"─" * (width - 2)`) collapsed to `╭╮`/`╰╯` while content rows overflowed
+    (gh #71). Floor at 40 so the banner always renders."""
     try:
-        return min(os.get_terminal_size().columns, 100)
+        cols = os.get_terminal_size().columns
     except OSError:
-        return 80
+        cols = 80
+    return min(max(cols, 40), 100)
 
 
 def separator(style: str = "light") -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.13"
+version = "0.6.14"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_terminal_width.py
+++ b/tests/test_terminal_width.py
@@ -1,0 +1,65 @@
+"""`get_terminal_width()` floors at a sane minimum so the header box never collapses (gh #71).
+
+A pty forked without an initialized window size (pexpect/expect automation, some CI
+pseudo-ttys, editor-integrated terminals, process supervisors) makes
+`os.get_terminal_size()` **succeed** and report `columns == 0` — it does NOT raise
+`OSError`, so the old `min(cols, 100)` returned 0 and the banner's borders
+(`"─" * (width - 2)` → `"─" * -2` → `""`) collapsed the box to a bare `╭╮`/`╰╯`.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from contextlib import redirect_stdout
+from unittest import mock
+
+from langstage_cli.cli import get_terminal_width, print_header_box, separator
+
+
+def _fake_size(cols):
+    return mock.patch("os.get_terminal_size", return_value=os.terminal_size((cols, 24)))
+
+
+def test_zero_columns_floors_instead_of_returning_zero():
+    # The bug: a real winsize-0 pty reports cols=0 without OSError; width must not be 0.
+    with _fake_size(0):
+        assert get_terminal_width() >= 40
+
+
+def test_tiny_columns_are_floored():
+    with _fake_size(5):
+        assert get_terminal_width() == 40
+
+
+def test_normal_width_passes_through():
+    with _fake_size(80):
+        assert get_terminal_width() == 80
+
+
+def test_wide_terminal_is_capped_at_100():
+    with _fake_size(1000):
+        assert get_terminal_width() == 100
+
+
+def test_oserror_still_falls_back_to_80():
+    with mock.patch("os.get_terminal_size", side_effect=OSError):
+        assert get_terminal_width() == 80
+
+
+def test_header_box_does_not_collapse_under_zero_width():
+    # The user-visible symptom: with cols=0 the top border was empty and the box became
+    # `╭╮`. Floored width means the border spans the full box, not just the corners.
+    with _fake_size(0):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_header_box("Demo Agent", "/tmp/x")
+        out = buf.getvalue()
+        # the top border line carries real horizontal rule between the corners
+        border = next(line for line in out.splitlines() if "╭" in line)
+        assert border.count("─") >= 30, f"header box collapsed: {border!r}"
+
+
+def test_separator_is_not_empty_under_zero_width():
+    with _fake_size(0):
+        assert "─" in separator("light")

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.13"
+version = "0.6.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

`get_terminal_width()` guarded `OSError` but not the case where `os.get_terminal_size()` **succeeds** and reports `columns == 0`:

```python
return min(os.get_terminal_size().columns, 100)   # min(0, 100) == 0
```

A pty forked without an initialized window size (pexpect/expect automation, some CI pseudo-ttys, editor-integrated terminals, process supervisors) makes `ioctl(TIOCGWINSZ)` return 0×0 — it does **not** raise `OSError`, so the existing guard never fired. With width 0, the box borders (`"─" * (width - 2)` → `"─" * -2` → `""`) vanished and the banner collapsed:

```
╭╮
│ Demo Agent │
│ cwd: ... │
╰╯
```

## Fix

Floor alongside the existing cap:

```python
try:
    cols = os.get_terminal_size().columns
except OSError:
    cols = 80
return min(max(cols, 40), 100)
```

## Tests

`tests/test_terminal_width.py`: cols 0 → floored (≥40), tiny → 40, normal → passthrough, wide → capped at 100, `OSError` → 80; and the header box + `separator()` no longer collapse under a winsize-0 pty.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)