### PR TITLE
fix: correct DEEPAGENT_SPEC deprecation notice + separate messages on the quiet path (gh #73, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.15 - 2026-07-12
+
+### Fixed
+- **Setting the documented `DEEPAGENT_SPEC` alias emitted a deprecation notice naming
+  `DEEPAGENT_AGENT_SPEC` — a variable the user never set (gh #73).** `CodeConfig.resolve()`
+  reconciles the oldest alias by copying `DEEPAGENT_SPEC` onto `DEEPAGENT_AGENT_SPEC` before
+  delegating to the shared resolver, so the resolver then emitted its **visible stderr
+  `note:`** for the synthesized `DEEPAGENT_AGENT_SPEC` — pointing the user at a var absent
+  from their environment and defeating the whole point of the nudge. The one correct signal
+  (`DEEPAGENT_SPEC`) was only a `DeprecationWarning`, which the default filter swallows. The
+  CLI now raises the deprecation through the shared resolver's own `_warn_legacy_env` helper
+  for `DEEPAGENT_SPEC` (so the message, dedupe, `LANGSTAGE_SUPPRESS_LEGACY_NOTICE` opt-out and
+  pytest suppression all match every other legacy-env notice) and marks the synthesized
+  `DEEPAGENT_AGENT_SPEC` already-warned so the resolver stays silent about it. The notice now
+  names the var the user actually set.
+
 ## 0.6.14 - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
   pytest suppression all match every other legacy-env notice) and marks the synthesized
   `DEEPAGENT_AGENT_SPEC` already-warned so the resolver stays silent about it. The notice now
   names the var the user actually set.
+- **Scriptable/quiet output concatenated a turn's separate messages with no separator (gh
+  #74).** The gh #43 node-change break — re-emitting the marker and inserting a newline when
+  the streaming node changes mid-turn — landed in the verbose and non-verbose branches of
+  `print_chunk()` but never covered the `_QUIET` / scriptable branch, so two `AIMessage`s from
+  two nodes in one turn (a common ReAct / plan→execute shape) were emitted back-to-back
+  (`…up.The capital…`) on the one output mode explicitly meant to be machine-parseable. The
+  quiet branch now tracks `_streaming_node` too and emits a bare `\n` (no marker, no color)
+  on a mid-turn node change; single-message token streaming still joins unbroken. Also, a
+  `BrokenPipeError` from an early-closing consumer (`| head`, `| grep -m1`) on the scriptable
+  path is now swallowed (the standard Python SIGPIPE recipe) and exits cleanly, instead of
+  surfacing a `⏺`-decorated error line to stderr.
 
 ## 0.6.14 - 2026-07-10
 

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -644,8 +644,19 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
             if _QUIET:
                 # Scriptable path (gh #53): emit the raw reply text only — no cyan
                 # bullet, no [node] label, and no markdown re-rendering, so a pipe
-                # gets exactly what the model produced.
+                # gets exactly what the model produced. But when the streaming node
+                # changes mid-turn, insert a bare newline (no marker/color) so two
+                # nodes' messages don't run together (…up.The capital…). The gh #43
+                # node-change break landed in the verbose/non-verbose branches but not
+                # here, so the scriptable path — the one output mode meant to be
+                # machine-parseable — was the only one that dropped the boundary
+                # (gh #74). Tokens of a single message share one node, so they still
+                # join unbroken.
+                if print_chunk._streaming_text and print_chunk._streaming_node != node:
+                    print()  # node changed mid-turn — break so the messages don't concatenate
                 print(text, end="", flush=True)
+                print_chunk._streaming_node = node
+                print_chunk._streaming_text = True
                 return
             if verbose:
                 # Print the [node] label ONCE per streamed run — when a text run
@@ -1788,6 +1799,21 @@ def main(
         if turn_had_error:
             sys.exit(1)
 
+    except BrokenPipeError:
+        # An early-closing consumer on the scriptable path (`| head`, `| grep -m1`, …)
+        # closes the pipe while we're still writing, raising BrokenPipeError. That is
+        # idiomatic, expected usage — not an error — so swallow it and exit quietly
+        # instead of surfacing the ⏺-decorated error line the generic handler below
+        # would (which also leaks the ⏺ glyph quiet mode otherwise suppresses).
+        # Redirect the remaining stdout to devnull so the interpreter's shutdown flush
+        # doesn't raise a second BrokenPipeError — the standard Python SIGPIPE recipe.
+        # (gh #74)
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except (OSError, ValueError):  # no real fd (e.g. under test capture) — nothing to redirect
+            pass
+        sys.exit(0)
     except FileNotFoundError as e:
         _status(f"{RED}⏺ Error: {e}{RESET}")
         sys.exit(1)

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -11,12 +11,12 @@ lookups.
 """
 
 import os
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, List, Optional, Tuple
 
 from langstage_core.host import HostConfig, load_toml_config
+from langstage_core.host.config import _warn_legacy_env, _warned_legacy_env
 
 
 class ConfigError(Exception):
@@ -113,9 +113,16 @@ class CodeConfig(HostConfig):
             and env.get("DEEPAGENT_SPEC")
         ):
             env["DEEPAGENT_AGENT_SPEC"] = env["DEEPAGENT_SPEC"]
-            warnings.warn(
-                "DEEPAGENT_SPEC is deprecated; use LANGSTAGE_AGENT_SPEC.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # Emit the deprecation signal for the var the user ACTUALLY set —
+            # DEEPAGENT_SPEC — through the shared resolver's own helper, so the
+            # DeprecationWarning, the visible stderr note, the once-per-var dedupe, the
+            # LANGSTAGE_SUPPRESS_LEGACY_NOTICE opt-out, and the pytest-note suppression
+            # all match every other legacy-env notice (gh #73).
+            _warn_legacy_env("DEEPAGENT_SPEC", "LANGSTAGE_AGENT_SPEC")
+            # The copy above populated DEEPAGENT_AGENT_SPEC only to keep the shared
+            # resolver's precedence chain intact; the user never set that var. Mark it
+            # already-warned so the resolver stays silent about it — otherwise the one
+            # signal a real user actually sees (the stderr note) would name a variable
+            # absent from their environment, defeating the deprecation nudge (gh #73).
+            _warned_legacy_env.add("DEEPAGENT_AGENT_SPEC")
         return super().resolve(env=env, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.14"
+version = "0.6.15"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_codeconfig.py
+++ b/tests/test_codeconfig.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from langstage_core.host import config as core_config
 from langstage_cli.config import CodeConfig
 
 
@@ -12,6 +13,12 @@ def isolated(tmp_path, monkeypatch):
     empty = tmp_path / "empty"
     empty.mkdir()
     monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(empty))
+    # The shared resolver dedupes each legacy-env notice once per process via a
+    # module-level set; clear the spec-alias entries so warning-asserting tests are
+    # order-independent (a prior resolve() in the same session would otherwise have
+    # already "warned" and silenced the DeprecationWarning these tests check).
+    for var in ("DEEPAGENT_SPEC", "DEEPAGENT_AGENT_SPEC"):
+        core_config._warned_legacy_env.discard(var)
     return tmp_path
 
 
@@ -54,6 +61,27 @@ def test_deepagent_spec_alias_is_deprecated(isolated, tmp_path):
     with pytest.warns(DeprecationWarning):
         cfg = CodeConfig.resolve(env={"DEEPAGENT_SPEC": "legacy.py:g"}, toml_start=tmp_path)
     assert cfg.agent_spec == "legacy.py:g"
+
+
+def test_deepagent_spec_alias_notice_names_the_var_the_user_set(isolated, tmp_path):
+    # gh #73: setting DEEPAGENT_SPEC must produce a deprecation notice that names
+    # DEEPAGENT_SPEC — the var actually in the user's environment — not
+    # DEEPAGENT_AGENT_SPEC, which the CLI only synthesizes internally to keep the
+    # shared resolver's precedence chain intact. Before the fix the CLI copied the
+    # value onto DEEPAGENT_AGENT_SPEC and the resolver then emitted the (visible)
+    # notice for THAT name, pointing the user at a variable they never set.
+    #
+    # The stderr note derives from the same _warn_legacy_env(legacy=...) call as the
+    # DeprecationWarning (and is pytest-suppressed), so asserting on the warning's
+    # name is a faithful proxy for the name the user-visible note carries.
+    with pytest.warns(DeprecationWarning) as records:
+        cfg = CodeConfig.resolve(env={"DEEPAGENT_SPEC": "legacy.py:g"}, toml_start=tmp_path)
+
+    assert cfg.agent_spec == "legacy.py:g"
+    messages = [str(w.message) for w in records]
+    assert any(m.startswith("DEEPAGENT_SPEC is deprecated") for m in messages), messages
+    # The bug: a second warning named DEEPAGENT_AGENT_SPEC, a var the user never set.
+    assert not any(m.startswith("DEEPAGENT_AGENT_SPEC is deprecated") for m in messages), messages
 
 
 def test_canonical_var_beats_alias(isolated, tmp_path):

--- a/tests/test_quiet_output.py
+++ b/tests/test_quiet_output.py
@@ -85,3 +85,55 @@ def test_interactive_default_keeps_decoration(capsys):
     print_chunk._streaming_node = None
     print_chunk({"status": "streaming", "chunk": "hi", "node": "n"})
     assert "⏺" in capsys.readouterr().out
+
+
+def test_print_chunk_quiet_breaks_between_nodes(capsys):
+    # gh #74: two AIMessages produced by different nodes in one turn (a ReAct /
+    # plan→execute shape) must not run together on the scriptable path. The gh #43
+    # node-change break covered the verbose/non-verbose branches but not _QUIET, so
+    # the two messages were emitted back-to-back (`…up.The capital…`) with no
+    # separator — on the one output mode meant to be machine-parseable. A bare
+    # newline (no marker, no color) now separates them.
+    c._QUIET = True
+    print_chunk._streaming_text = False
+    print_chunk._streaming_node = None
+    print_chunk({"status": "streaming", "chunk": "Let me look that up.", "node": "think"})
+    print_chunk(
+        {"status": "streaming", "chunk": "The capital of France is Paris.", "node": "answer"}
+    )
+    out = capsys.readouterr().out
+    assert out == "Let me look that up.\nThe capital of France is Paris.", repr(out)
+    # No decoration leaks onto the scriptable stream — only the boundary newline.
+    assert "⏺" not in out and "\x1b[" not in out, repr(out)
+
+
+def test_print_chunk_quiet_single_node_tokens_join_unbroken(capsys):
+    # Contrast (gh #74): tokens of ONE message share a node, so they must still join
+    # with no separator — that's correct token streaming; only the cross-node
+    # boundary is a break.
+    c._QUIET = True
+    print_chunk._streaming_text = False
+    print_chunk._streaming_node = None
+    for tok in ["Hel", "lo ", "world"]:
+        print_chunk({"status": "streaming", "chunk": tok, "node": "answer"})
+    out = capsys.readouterr().out
+    assert out == "Hello world", repr(out)
+
+
+def test_broken_pipe_is_swallowed_not_surfaced(tmp_path, monkeypatch):
+    # gh #74 (secondary): an early-closing consumer (`| head`, `| grep -m1`) closes
+    # the pipe mid-write, raising BrokenPipeError. That is idiomatic scriptable usage,
+    # not a failure — it must be swallowed (Python's usual SIGPIPE handling) and exit
+    # cleanly, never surfaced as a ⏺-decorated error line (the glyph quiet mode
+    # otherwise suppresses).
+    monkeypatch.chdir(tmp_path)
+
+    def _raise_broken_pipe(*args, **kwargs):
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(c, "run_conversation_loop", _raise_broken_pipe)
+    r = CliRunner().invoke(main, ["--demo", "hi"])
+    assert r.exit_code == 0, r.output
+    assert "Broken pipe" not in r.output, r.output
+    assert "⏺" not in r.output, r.output
+    assert "Error" not in r.output, r.output


### PR DESCRIPTION
Two dogfood-filed bugs on documented, user-facing paths. One branch, one commit per issue, released as `0.6.15`.

## Closes #73 — `DEEPAGENT_SPEC` alias emits a notice naming a var the user never set

Setting the documented `DEEPAGENT_SPEC` alias printed a stderr deprecation `note:` naming **`DEEPAGENT_AGENT_SPEC`** — a variable absent from the user's environment — defeating the whole point of the nudge.

**Root cause:** `CodeConfig.resolve()` reconciles the oldest alias by copying `DEEPAGENT_SPEC` onto `DEEPAGENT_AGENT_SPEC` before delegating to the shared resolver. The resolver then sees the now-populated `DEEPAGENT_AGENT_SPEC` and emits its **visible** stderr notice for *that* name. The correct signal (a `DeprecationWarning` naming `DEEPAGENT_SPEC`) is swallowed by Python's default warning filter, so the only line a real user sees was wrong.

**Fix (`langstage_cli/config.py`):** raise the deprecation through the shared resolver's own `_warn_legacy_env("DEEPAGENT_SPEC", …)` helper — so the message text, once-per-var dedupe, `LANGSTAGE_SUPPRESS_LEGACY_NOTICE` opt-out and pytest-note suppression all match every other legacy-env notice — and add the synthesized `DEEPAGENT_AGENT_SPEC` to the resolver's `_warned_legacy_env` set so it stays silent about the var it only populated internally.

**Verified:**
- New `tests/test_codeconfig.py::test_deepagent_spec_alias_notice_names_the_var_the_user_set` asserts the emitted warning starts with `DEEPAGENT_SPEC is deprecated` and that no warning names `DEEPAGENT_AGENT_SPEC`. Fails before, passes after.
- End-to-end (outside pytest, where the note is suppressed): setting `DEEPAGENT_SPEC` now prints `note: DEEPAGENT_SPEC is deprecated; use LANGSTAGE_AGENT_SPEC. …`; `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1` silences it; setting `DEEPAGENT_AGENT_SPEC` directly still correctly names `DEEPAGENT_AGENT_SPEC` (no regression).

## Closes #74 — quiet/scriptable output concatenates a turn's separate messages

The gh #43 node-change break (insert a newline + re-emit the marker when the streaming node changes mid-turn) landed in the verbose and non-verbose branches of `print_chunk()` but **never covered the `_QUIET` / scriptable branch**. Two `AIMessage`s from two nodes in one turn (a common ReAct / plan→execute shape) were emitted back-to-back — `…up.The capital…` — on the one output mode explicitly meant to be machine-parseable.

**Fix (`langstage_cli/cli.py`):** the quiet branch now tracks `_streaming_node` too and emits a bare `\n` (no marker, no color) when the node changes after text has already been printed. Single-message token streaming (same node) still joins unbroken.

**Secondary defect on the same surface (also fixed):** a `BrokenPipeError` from an early-closing consumer (`| head`, `| grep -m1`) surfaced a `⏺`-decorated `Error: [Errno 32] Broken pipe` on stderr. `main()` now catches it, applies the standard Python SIGPIPE recipe (redirect the remaining stdout to devnull so the shutdown flush can't raise again) and exits cleanly.

**Verified:**
- New `tests/test_quiet_output.py::test_print_chunk_quiet_breaks_between_nodes` (two nodes → `Let me look that up.\nThe capital of France is Paris.`), `…_single_node_tokens_join_unbroken` (contrast guard), and `…test_broken_pipe_is_swallowed_not_surfaced` (exit 0, no `⏺`/`Error`/`Broken pipe`). The two behavior tests fail before, pass after.
- End-to-end through the real CLI with the issue's two-node `react.py`: the piped reply is now two lines; `… 2>err.txt | head -c 10` exits 0 with an empty `err.txt`.

## Test evidence

Full suite green on the committed tree: **95 passed**. `ruff check .` and `ruff format --check .` both clean (matches CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
