### PR TITLE
fix: complete the _QUIET gating on print_chunk()'s interrupt + error surfaces (Closes #76, #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 0.6.16 - 2026-07-14
 
 ### Fixed
+- **Quiet/scriptable mode leaked the `⚠ Action Required` HITL banner onto stdout (gh #77).**
+  The interrupt branch of `print_chunk()` never got the `_QUIET` gate its sibling
+  tool-call/tool-result branches have, so when an agent raised an `interrupt()` on the
+  documented `--no-interactive` auto-approve + piped/quiet path, the `⚠ Action Required`
+  banner, a leading blank line, and the pending-action list were printed to **stdout** — ahead
+  of the real reply — corrupting the machine-readable output that a scripting consumer captures
+  (and the run still exited `0`, so nothing signalled the corruption). Unlike #76 (stderr only),
+  this landed on the very stream a script reads. The interrupt branch now returns early in quiet
+  mode, so stdout carries only the agent's reply; the `Auto-approving …` diagnostic still goes to
+  stderr, so a log/human still sees what was approved.
 - **Quiet/scriptable error output still leaked the `⏺` glyph on every error path except
   `BrokenPipeError` (gh #76).** Errors already route to stderr with color stripped, but the
   `⏺` in `_status(f"{RED}⏺ Error: {e}{RESET}")` is a literal glyph, not an ANSI code, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 0.6.15 - 2026-07-12
+## 0.6.16 - 2026-07-14
+
+### Fixed
+- **Quiet/scriptable error output still leaked the `⏺` glyph on every error path except
+  `BrokenPipeError` (gh #76).** Errors already route to stderr with color stripped, but the
+  `⏺` in `_status(f"{RED}⏺ Error: {e}{RESET}")` is a literal glyph, not an ANSI code, so
+  `_disable_ansi()` (which blanks `RED`/`RESET`) left it in place — the #74 fix only routed
+  around it for `BrokenPipeError`, so every other path (bad/missing agent spec, load failure,
+  a node exception, the generic top-level handlers) still printed `⏺ Error: …`, and on a
+  Windows cp1252 console the glyph became a `?`/replacement char via the `errors="replace"`
+  reconfigure. `_status()` now drops a leading `⏺ ` marker in quiet mode, in one place, so
+  every error/diagnostic path matches the bare `Error: …` that `print_chunk` already emits on
+  its own quiet error branch — completing the #74 suppression instead of special-casing one
+  exception type.
 
 ### Fixed
 - **Setting the documented `DEEPAGENT_SPEC` alias emitted a deprecation notice naming

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -723,6 +723,15 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
 
     elif status == "interrupt":
         print_chunk._streaming_text = False
+        if _QUIET:
+            # The `⚠ Action Required` banner is human-facing decoration — like the
+            # tool-call / tool-result chatter above, the scriptable path omits it so
+            # the machine-readable reply on stdout carries ONLY the agent's text and
+            # is never corrupted by the banner (a leading blank line, the literal `⚠`
+            # glyph, and the pending-action list). Under --no-interactive the
+            # `Auto-approving …` diagnostic still goes to stderr, so a log/human still
+            # sees what was approved. (gh #77)
+            return
         interrupt_data = chunk.get("interrupt", {})
         action_requests = interrupt_data.get("action_requests", [])
 

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -72,7 +72,18 @@ def _disable_ansi() -> None:
 
 def _status(msg: str) -> None:
     """Emit a status/diagnostic line off the reply stream: to stderr in quiet
-    mode (so it never pollutes the piped answer), to stdout otherwise."""
+    mode (so it never pollutes the piped answer), to stdout otherwise.
+
+    In quiet/scriptable mode also drop a leading ``⏺ `` marker. The glyph is a
+    literal in the caller's f-string (``f"{RED}⏺ Error: …{RESET}"``), not an ANSI
+    code, so ``_disable_ansi()`` — which blanks the surrounding color — leaves it
+    in place. Quiet mode is documented to suppress it, and the #74 fix only routed
+    around it for ``BrokenPipeError``; stripping it here, in one place, completes
+    that suppression so every error/diagnostic path matches the bare ``Error: …``
+    that ``print_chunk`` already emits on its own quiet error branch. (gh #76)
+    """
+    if _QUIET:
+        msg = msg.removeprefix("⏺ ")
     print(msg, file=sys.stderr if _QUIET else sys.stdout)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.15"
+version = "0.6.16"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_quiet_output.py
+++ b/tests/test_quiet_output.py
@@ -13,7 +13,7 @@ piped path these tests care about.
 from click.testing import CliRunner
 
 from langstage_cli import cli as c
-from langstage_cli.cli import main, print_chunk
+from langstage_cli.cli import main, print_chunk, _status
 
 
 def test_piped_single_shot_is_only_the_reply(tmp_path, monkeypatch):
@@ -118,6 +118,42 @@ def test_print_chunk_quiet_single_node_tokens_join_unbroken(capsys):
         print_chunk({"status": "streaming", "chunk": tok, "node": "answer"})
     out = capsys.readouterr().out
     assert out == "Hello world", repr(out)
+
+
+def test_status_strips_error_glyph_in_quiet(capsys):
+    # gh #76: the `⏺` in `_status(f"{RED}⏺ Error: …{RESET}")` is a literal glyph, not
+    # ANSI, so _disable_ansi() (which blanks RED/RESET) leaves it. Quiet mode routes
+    # the line to stderr AND must drop the glyph, matching print_chunk's bare
+    # `Error: …` quiet contract. Emulate a real quiet run: ansi disabled + _QUIET set.
+    c._disable_ansi()
+    c._QUIET = True
+    _status(f"{c.RED}⏺ Error: Agent file not found: /no/such/agent.py{c.RESET}")
+    captured = capsys.readouterr()
+    assert captured.out == "", repr(captured.out)  # reply stream stays clean
+    assert captured.err == "Error: Agent file not found: /no/such/agent.py\n", repr(captured.err)
+    assert "⏺" not in captured.err, repr(captured.err)
+
+
+def test_status_keeps_glyph_and_uses_stdout_when_not_quiet(capsys):
+    # The interactive (non-quiet) path is unchanged: the glyph stays and the line
+    # goes to stdout, so the terminal keeps its familiar decoration.
+    c._QUIET = False
+    _status("⏺ Error: boom")
+    captured = capsys.readouterr()
+    assert captured.out == "⏺ Error: boom\n", repr(captured.out)
+    assert captured.err == "", repr(captured.err)
+
+
+def test_error_stderr_has_no_glyph_in_quiet(tmp_path, monkeypatch):
+    # gh #76 end-to-end: a load error on the scriptable path routes to stderr (stdout
+    # stays clean) but must not carry the `⏺` glyph — the #74 suppression only covered
+    # BrokenPipeError, so every other error path still leaked it via _status().
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["-a", "no_such_module_xyz:graph", "hi"])
+    assert r.exit_code == 1
+    assert r.stdout.strip() == "", r.stdout  # nothing on the reply stream
+    assert "Error" in r.stderr, r.stderr
+    assert "⏺" not in r.stderr, repr(r.stderr)
 
 
 def test_broken_pipe_is_swallowed_not_surfaced(tmp_path, monkeypatch):

--- a/tests/test_quiet_output.py
+++ b/tests/test_quiet_output.py
@@ -120,6 +120,78 @@ def test_print_chunk_quiet_single_node_tokens_join_unbroken(capsys):
     assert out == "Hello world", repr(out)
 
 
+_HITL_AGENT = """
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import MessagesState
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import interrupt
+from langchain_core.messages import AIMessage
+
+def ask(state):
+    decision = interrupt({"action": "delete_file", "path": "/etc/passwd"})
+    return {"messages": [AIMessage(content=f"Decision was: {decision}")]}
+
+g = StateGraph(MessagesState)
+g.add_node("ask", ask)
+g.add_edge(START, "ask")
+g.add_edge("ask", END)
+graph = g.compile(checkpointer=MemorySaver())
+"""
+
+
+def test_print_chunk_quiet_suppresses_hitl_banner(capsys):
+    # gh #77: the `⚠ Action Required` HITL banner is human decoration. On the
+    # scriptable path it must not reach stdout — it would corrupt the machine-readable
+    # reply (a leading blank line, the literal `⚠` glyph, and the action list, ahead
+    # of the real text). Like tool chatter, the interrupt branch is fully omitted in
+    # quiet mode; nothing leaks to stderr either (the banner is suppressed, not rerouted).
+    c._QUIET = True
+    print_chunk._streaming_text = False
+    print_chunk._streaming_node = None
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {
+                "action_requests": [{"action": "delete_file", "args": {"path": "/etc/passwd"}}]
+            },
+        }
+    )
+    captured = capsys.readouterr()
+    assert captured.out == "", repr(captured.out)  # reply stream stays clean
+    assert "⚠" not in captured.out and "Action Required" not in captured.out
+    assert captured.err == "", repr(captured.err)
+
+
+def test_print_chunk_interactive_keeps_hitl_banner(capsys):
+    # Contrast: the default (non-quiet) path still renders the banner and the pending
+    # action so an operator can see what they are approving (the gh #69 tool name).
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {"action_requests": [{"action": "delete_file", "args": {}}]},
+        }
+    )
+    out = capsys.readouterr().out
+    assert "Action Required" in out, repr(out)
+    assert "delete_file" in out, repr(out)
+
+
+def test_hitl_quiet_stdout_is_only_the_reply(tmp_path, monkeypatch):
+    # gh #77 end-to-end: a HITL agent run with --no-interactive on the scriptable path
+    # (single-shot + piped => quiet). stdout must be ONLY the agent's reply — no banner,
+    # no `⚠`, no leading blank line — while the auto-approve diagnostic stays on stderr.
+    (tmp_path / "hitl_agent.py").write_text(_HITL_AGENT)
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["-a", "hitl_agent.py:graph", "go", "--no-interactive"])
+    assert r.exit_code == 0, r.output
+    assert r.stdout == "Decision was: {'decisions': [{'type': 'approve'}]}\n", repr(r.stdout)
+    assert "⚠" not in r.stdout and "Action Required" not in r.stdout, repr(r.stdout)
+    # The auto-approve diagnostic is off the reply stream, on stderr.
+    assert "Auto-approving" in r.stderr, repr(r.stderr)
+
+
 def test_status_strips_error_glyph_in_quiet(capsys):
     # gh #76: the `⏺` in `_status(f"{RED}⏺ Error: …{RESET}")` is a literal glyph, not
     # ANSI, so _disable_ansi() (which blanks RED/RESET) leaves it. Quiet mode routes


### PR DESCRIPTION
## Summary

Two gaps in the `_QUIET`/scriptable path of `langstage_cli/cli.py` — the same class as the already-merged #74, but on other surfaces. Quiet/scriptable mode is documented to emit *"only the agent's reply"* with *"the header, spinner, tool chatter, timing, and color"* suppressed; these two paths still leaked decoration.

Both fixes extend the existing `_QUIET` gating consistently with the sibling branches; no behavior changes outside quiet mode.

Closes #76
Closes #77

### #77 — HITL banner leaked onto **stdout** (Major)

The interrupt branch of `print_chunk()` never got the `_QUIET` gate its sibling tool-call / tool-result branches have. So an agent that raises `interrupt()` on the documented `--no-interactive` auto-approve + piped/quiet path printed the `⚠ Action Required` banner, a leading blank line, and the pending-action list to **stdout**, ahead of the real reply — corrupting the machine-readable output a scripting consumer captures, while the run still exited `0`. Unlike #76 (stderr only), this lands on the very stream a script reads.

**Fix:** the interrupt branch now returns early in quiet mode (like the tool chatter above), so stdout carries only the agent's reply. The `Auto-approving …` diagnostic still goes to stderr, so a log/human still sees what was approved.

### #76 — `⏺` glyph leaked on every non-`BrokenPipeError` error path (Minor)

Errors already route to stderr with color stripped, but the `⏺` in `_status(f"{RED}⏺ Error: {e}{RESET}")` is a literal glyph, not an ANSI code, so `_disable_ansi()` (which blanks `RED`/`RESET`) left it in place. The #74 change only routed around it for `BrokenPipeError`; every other path (bad/missing agent spec, load failure, node exception, the generic handlers) still leaked `⏺ Error: …` — a `?`/replacement char on a Windows cp1252 console — inconsistent with the bare `Error: …` that `print_chunk`'s own quiet error branch already emits.

**Fix:** `_status()` drops a leading `⏺ ` marker in quiet mode, in one place, so every error/diagnostic path matches that bare contract — completing the #74 suppression instead of special-casing one exception type.

## Testing

- New tests in `tests/test_quiet_output.py` (unit + end-to-end), each verified fail-before / pass-after:
  - `test_print_chunk_quiet_suppresses_hitl_banner`, `test_hitl_quiet_stdout_is_only_the_reply` (#77), with `test_print_chunk_interactive_keeps_hitl_banner` as the non-quiet contrast guard.
  - `test_status_strips_error_glyph_in_quiet`, `test_error_stderr_has_no_glyph_in_quiet` (#76), with `test_status_keeps_glyph_and_uses_stdout_when_not_quiet` as the non-quiet contrast guard.
- Full suite: **101 passed** (was 95). `ruff check .` and `ruff format --check .` both clean.
- Version bumped to **0.6.16**; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
