### PR TITLE
fix: bare /verbose toggles instead of only printing state (Closes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.17 - 2026-07-15
+
+### Fixed
+- **Bare `/verbose` never toggled despite being advertised as "Toggle verbose output mode"
+  (gh #79).** The interactive `/verbose` command is registered — and shown in `/help` — as
+  "Toggle verbose output mode", but the shipped bare form (`/verbose` with no argument) only
+  *printed* the current state and told the user to run `/verbose on|off`; it flipped nothing.
+  A one-word command named "Toggle" that no-ops is the same "advertised != honoured" class as
+  #62/#66/#36, on the interactive command surface. `cmd_verbose` now flips the value on a bare
+  call and reports the new state (`✓ Verbose mode enabled`/`disabled`), matching the `/help`
+  description and the one-word command name. The explicit `/verbose on|off` (and the `true/1`,
+  `false/0` synonyms) form is unchanged — it still *sets* the value rather than toggling — and
+  an unrecognised argument now prints `Usage: /verbose [on|off]` instead of silently emitting a
+  misleading confirmation.
+
 ## 0.6.16 - 2026-07-14
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -1160,18 +1160,26 @@ def cmd_reset(args: str, context: Dict[str, Any]) -> Optional[str]:
     usage="/verbose [on|off]",
 )
 def cmd_verbose(args: str, context: Dict[str, Any]) -> Optional[str]:
-    """Toggle or show verbose output mode."""
+    """Toggle or set verbose output mode.
+
+    Bare ``/verbose`` flips the current value — honouring the advertised "Toggle
+    verbose output mode" contract (gh #79) — while ``/verbose on|off`` sets it
+    explicitly. Either way the new state is reported.
+    """
     verbose = context.get("verbose", False)
     if args:
         if args.lower() in ("on", "true", "1"):
-            context["verbose"] = True
-            print(f"{GREEN}✓ Verbose mode enabled{RESET}")
+            verbose = True
         elif args.lower() in ("off", "false", "0"):
-            context["verbose"] = False
-            print(f"{GREEN}✓ Verbose mode disabled{RESET}")
+            verbose = False
+        else:
+            print(f"{YELLOW}Usage: /verbose [on|off]{RESET}")
+            return None
     else:
-        print(f"{DIM}Verbose mode: {'on' if verbose else 'off'}{RESET}")
-        print(f"{DIM}Use /verbose on or /verbose off to change{RESET}")
+        # Bare /verbose toggles, matching the "Toggle" description (gh #79).
+        verbose = not verbose
+    context["verbose"] = verbose
+    print(f"{GREEN}✓ Verbose mode {'enabled' if verbose else 'disabled'}{RESET}")
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.16"
+version = "0.6.17"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_verbose_command.py
+++ b/tests/test_verbose_command.py
@@ -1,0 +1,85 @@
+"""Bare `/verbose` honours its advertised "Toggle verbose output mode" contract (gh #79).
+
+`/verbose` is registered — and shown in `/help` — as "Toggle verbose output mode", but the
+shipped bare form only *printed* the current state and told the user to type `/verbose on|off`;
+it never flipped anything. A one-word command called "Toggle" that no-ops is advertised !=
+honoured. `cmd_verbose` now flips the value on a bare call and reports the new state, while the
+explicit `/verbose on|off` form keeps setting it. These tests fail before the fix (the bare
+calls left `verbose` unchanged) and pass after.
+"""
+
+from langstage_cli.cli import cmd_verbose, command_registry
+
+
+def test_bare_verbose_toggles_from_off_to_on():
+    ctx = {"verbose": False}
+    cmd_verbose("", ctx)
+    assert ctx["verbose"] is True
+
+
+def test_bare_verbose_toggles_from_on_to_off():
+    ctx = {"verbose": True}
+    cmd_verbose("", ctx)
+    assert ctx["verbose"] is False
+
+
+def test_two_bare_verbose_calls_flip_then_flip_back():
+    # The exact reproduction from #79: two consecutive bare /verbose from the default.
+    ctx = {"verbose": False}
+    cmd_verbose("", ctx)
+    assert ctx["verbose"] is True
+    cmd_verbose("", ctx)
+    assert ctx["verbose"] is False
+
+
+def test_bare_verbose_defaults_to_off_then_toggles_on():
+    # No "verbose" key set yet — defaults to off, so a bare toggle turns it on.
+    ctx = {}
+    cmd_verbose("", ctx)
+    assert ctx["verbose"] is True
+
+
+def test_bare_verbose_reports_the_new_state():
+    ctx = {"verbose": False}
+    import io
+    import contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        cmd_verbose("", ctx)
+    out = buf.getvalue()
+    # Reports the *new* state (enabled), not a bare "Verbose mode: off" read-out.
+    assert "enabled" in out
+    assert "Use /verbose on or /verbose off to change" not in out
+
+
+def test_explicit_on_off_still_sets_state():
+    ctx = {"verbose": False}
+    cmd_verbose("on", ctx)
+    assert ctx["verbose"] is True
+    cmd_verbose("off", ctx)
+    assert ctx["verbose"] is False
+    # Idempotent: explicit set does not toggle — /verbose off from off stays off.
+    cmd_verbose("off", ctx)
+    assert ctx["verbose"] is False
+
+
+def test_unknown_arg_does_not_change_state_or_falsely_confirm():
+    ctx = {"verbose": True}
+    import io
+    import contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        cmd_verbose("bogus", ctx)
+    out = buf.getvalue()
+    assert ctx["verbose"] is True  # unchanged
+    assert "Usage:" in out
+    assert "enabled" not in out and "disabled" not in out
+
+
+def test_help_description_stays_toggle():
+    # The command is still advertised as a toggle; behaviour now matches the ad.
+    cmd = command_registry.get("verbose")
+    assert cmd is not None
+    assert cmd.description == "Toggle verbose output mode"


### PR DESCRIPTION
## Summary

`/verbose` is registered — and shown in `/help` — as **"Toggle verbose output mode"**, but the shipped bare form (`/verbose` with no argument) only *printed* the current state and told the user to run `/verbose on|off`. It flipped nothing, so a one-word command literally named "Toggle" was a no-op — the same "advertised != honoured" class as #62/#66/#36, on the interactive command surface.

This makes bare `/verbose` **toggle** the flag and report the new state, honouring the `/help` description and the one-word command name (issue option **(a)**).

## Root cause

In `cmd_verbose` (`langstage_cli/cli.py`), the no-args `else` branch only printed state:

```python
else:
    print(f"{DIM}Verbose mode: {'on' if verbose else 'off'}{RESET}")
    print(f"{DIM}Use /verbose on or /verbose off to change{RESET}")   # never toggled
```

The interactive loop already propagates `context["verbose"]` back into the live render flag after each command (`verbose = command_context.get("verbose", verbose)`), so flipping the value takes effect immediately.

## Fix

- Bare `/verbose` now flips the value (`verbose = not verbose`) and prints `✓ Verbose mode enabled` / `disabled`.
- The explicit `/verbose on|off` form (plus the existing `true/1`, `false/0` synonyms) is **preserved** — it still *sets* rather than toggles, so `/verbose off` from off stays off.
- An unrecognised argument (previously a silent no-op) now prints `Usage: /verbose [on|off]` and returns without emitting a misleading `✓ Verbose mode …` confirmation.
- The `/help` description stays "Toggle verbose output mode" — behaviour now matches the ad.

## Tests

New `tests/test_verbose_command.py` (8 tests). The 6 bare-toggle / new-state / unknown-arg tests **fail before** the source change and **pass after**; the explicit-set and description tests cover already-correct behaviour and guard against regression. Includes the issue's exact reproduction (two consecutive bare `/verbose` from the default flip on then off).

Full suite: **109 passed** (was 101). `ruff check .` and `ruff format --check .` clean across the tree.

Version bumped 0.6.16 → 0.6.17 with a CHANGELOG entry, per convention.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
