### PR TITLE
docs: complete the README /commands list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.18 - 2026-07-15
+
+### Documentation
+- **README `## Commands` section was stale — it listed only 6 of the 9 interactive slash
+  commands.** Missing entirely were `/status`, `/version`, and `/verbose`; `/reset` omitted its
+  `/restart` alias; and `/config` was described as show-only when it also sets a runtime key
+  (`/config [key] [value]`). The section now lists every registered command with its aliases and
+  accurate description, matching what `/help` prints in the loop. Docs-only; no code change.
+
 ## 0.6.17 - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,12 +93,15 @@ langstage-cli --show-config
 ## Commands
 
 In the interactive loop:
-- `/quit` (`/q`, `/exit`) - Exit
+- `/help` (`/h`, `/?`) - Show this help message, or `/help <command>` for one command
+- `/status` (`/s`) - Show session status (agent, thread, sync/async mode, verbose, cwd)
+- `/version` (`/v`) - Show version and the current agent
+- `/config` (`/cfg`) - Show the resolved configuration, or set a runtime key: `/config [key] [value]`
+- `/verbose` - Toggle verbose output, or set it explicitly: `/verbose [on|off]`
+- `/history` (`/hist`) - Show recent conversation messages, optionally `/history [N]`
 - `/clear` (`/c`) - Clear conversation history
-- `/reset` - Reset the session
-- `/config` (`/cfg`) - Show the resolved configuration
-- `/history` (`/hist`) - Show conversation history
-- `/help` (`/h`, `/?`) - Show help
+- `/reset` (`/restart`) - Reset the session (clear history and start a new thread)
+- `/quit` (`/q`, `/exit`) - Exit
 - **Tab** autocompletes commands; **Ctrl+C** exits
 
 ## Environment Variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.17"
+version = "0.6.18"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The README `## Commands` section listed only **6 of the 9** interactive slash commands. This is the doc-drift the routine flagged alongside #79.

**Missing / wrong:**
- `/status`, `/version`, `/verbose` — absent entirely
- `/reset` — omitted its `/restart` alias
- `/config` — described as show-only, but it also **sets** a runtime key (`/config [key] [value]`)

The section now lists every registered command with accurate aliases and descriptions, matching what `/help` prints in the loop.

Docs-only; no behavior change. Bumps 0.6.17 → 0.6.18 so the rendered README on PyPI refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY