### PR TITLE
fix: render any generic interrupt payload in the HITL approval prompt (Closes #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.19 - 2026-07-16
+
+### Fixed
+- **The HITL approval prompt rendered nothing useful for a *generic* LangGraph `interrupt(...)`
+  (gh #82).** #69 wired the deepagents `ActionRequest` shape (tool name under `action`), but the
+  renderer still assumed *every* interrupt was that shape, so an arbitrary `interrupt(...)` value —
+  the canonical HITL primitive from the LangGraph docs — was dropped: a plain dict such as
+  `interrupt({"question": "..."})` rendered `1. unknown` (silently discarding the `question` and
+  every other non-`action`/`tool`/`args` key), and a bare-string interrupt reaching the renderer as
+  a string `action_request` raised `'str' object has no attribute 'get'`. Either way the operator was
+  asked to approve or reject an action they could not see — and because approval can gate destructive
+  work, approving blind is a real hazard, not a cosmetic gap. `print_chunk()`'s interrupt branch now
+  renders **any** payload actionably via a new `format_interrupt_request()` helper: a bare string /
+  scalar shows the value itself; a dict without a recognized tool key surfaces its first
+  human-readable field (`description`/`question`/`message`/`prompt`) or, failing that, a compact JSON
+  repr of the whole payload instead of `unknown`; and the structured `action`/`tool` + args path is
+  unchanged. When `action_requests` is empty (a bare-string interrupt's payload is JSON-decoded to
+  `{}` and dropped upstream by `langstage-core`'s AG-UI adapter), the CLI now renders a surviving raw
+  interrupt `value` if present, else notes `(no action details provided)` so the banner is never
+  silently contentless. The invariant: the approval prompt must never ask the user to approve an
+  action whose description it silently threw away.
+
 ## 0.6.18 - 2026-07-15
 
 ### Documentation

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -603,6 +603,43 @@ def get_tool_arg_preview(args: Dict[str, Any]) -> str:
     return first_val
 
 
+def format_interrupt_request(action: Any) -> Tuple[str, str]:
+    """Render one HITL interrupt ``action_request`` to a ``(label, preview)`` pair.
+
+    A generic LangGraph ``interrupt(...)`` may carry ANY value, not just a
+    deepagents ``ActionRequest``. The renderer must never ask the user to approve
+    an action whose description it silently threw away (gh #82):
+
+    - a deepagents/langchain ``ActionRequest`` (tool name under ``action`` — the
+      convention #69 fixed — or the legacy ``tool`` key) -> tool name + first-arg
+      preview, unchanged;
+    - any other dict -> its first human-readable field
+      (``description``/``question``/``message``/``prompt``), else a compact JSON
+      repr of the whole payload — instead of the old, content-dropping ``unknown``;
+    - a bare string / scalar -> the value itself (a ``.get`` on it used to raise).
+    """
+    if isinstance(action, dict):
+        tool = action.get("action") or action.get("tool")
+        if tool:
+            return str(tool), get_tool_arg_preview(action.get("args", {}))
+        for key in ("description", "question", "message", "prompt"):
+            val = action.get(key)
+            if isinstance(val, str) and val.strip():
+                return val, ""
+        # No recognized field — surface the payload compactly, never "unknown".
+        return _compact_repr(action), ""
+    return str(action), ""
+
+
+def _compact_repr(value: Any) -> str:
+    """A one-line, length-capped repr for an unrecognized interrupt payload."""
+    try:
+        text = json.dumps(value, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(value)
+    return text if len(text) <= 120 else text[:120] + "..."
+
+
 def format_result_preview(result: str) -> str:
     """Format a result preview with line count indicator."""
     if not result:
@@ -738,15 +775,28 @@ def print_chunk(chunk: Dict[str, Any], verbose: bool = False):
         print(f"\n{YELLOW}⚠ Action Required{RESET}")
         if action_requests:
             for i, action in enumerate(action_requests):
-                # The HumanInterrupt action_request keys the tool name under "action"
-                # (deepagents/langchain convention); a bare `.get("tool")` always missed
-                # and rendered "unknown" (gh #69). Fall back to "tool" for any agent that
-                # uses the older key, then to "unknown". Mirrors the vscode #44 fix.
-                tool = action.get("action") or action.get("tool") or "unknown"
-                args_preview = get_tool_arg_preview(action.get("args", {}))
-                print(f"  {DIM}{i + 1}. {tool}{RESET}")
+                # #69 taught the deepagents/langchain `ActionRequest` shape (tool name
+                # under `action`). But a generic `interrupt(...)` carries arbitrary
+                # values — a plain dict rendered `1. unknown` (dropping e.g. `question`)
+                # and a bare string raised `'str' has no attribute 'get'`. Render ANY
+                # payload actionably (gh #82); the structured tool path is unchanged.
+                label, args_preview = format_interrupt_request(action)
+                print(f"  {DIM}{i + 1}. {label}{RESET}")
                 if args_preview:
                     print(f"     {DIM}└─ {args_preview}{RESET}")
+        else:
+            # No structured action_requests. A bare-string/scalar interrupt loses its
+            # payload upstream (core's AG-UI adapter JSON-decodes it to `{}`), but if a
+            # raw value survives on the frame, surface it; otherwise say so, so the user
+            # never approves against a blank, contentless banner. (gh #82)
+            raw = interrupt_data.get("value")
+            if raw is None:
+                raw = interrupt_data.get("interrupt")
+            if raw in (None, "", {}, []):
+                print(f"  {DIM}(no action details provided){RESET}")
+            else:
+                label, _ = format_interrupt_request(raw)
+                print(f"  {DIM}{label}{RESET}")
 
     elif status == "complete":
         print_chunk._streaming_text = False  # turn over; next turn starts a fresh marker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.18"
+version = "0.6.19"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_quiet_output.py
+++ b/tests/test_quiet_output.py
@@ -178,6 +178,105 @@ def test_print_chunk_interactive_keeps_hitl_banner(capsys):
     assert "delete_file" in out, repr(out)
 
 
+def test_hitl_renders_structured_action_with_args_unchanged(capsys):
+    # gh #82 regression guard: the deepagents ActionRequest path (#69) must render
+    # exactly as before — tool name from the `action` key plus a first-arg preview.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {
+                "action_requests": [{"action": "delete_file", "args": {"path": "/etc/passwd"}}]
+            },
+        }
+    )
+    out = capsys.readouterr().out
+    assert "1. delete_file" in out, repr(out)
+    assert "/etc/passwd" in out, repr(out)  # args preview intact
+    assert "unknown" not in out, repr(out)
+
+
+def test_hitl_renders_bare_string_interrupt(capsys):
+    # gh #82: a generic `interrupt("Approve ...?")` reaching the renderer as a bare
+    # string action_request used to raise `'str' object has no attribute 'get'`; the
+    # user must instead SEE the string they are approving.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {"action_requests": ["Approve deleting production database? (yes/no)"]},
+        }
+    )
+    out = capsys.readouterr().out
+    assert "Action Required" in out, repr(out)
+    assert "Approve deleting production database? (yes/no)" in out, repr(out)
+    assert "unknown" not in out, repr(out)
+
+
+def test_hitl_renders_plain_dict_interrupt_content(capsys):
+    # gh #82: `interrupt({"question": "..."})` used to render `1. unknown`, silently
+    # dropping the question. The human-readable field must be surfaced instead.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {"action_requests": [{"question": "Approve deleting file X?"}]},
+        }
+    )
+    out = capsys.readouterr().out
+    assert "Approve deleting file X?" in out, repr(out)
+    assert "unknown" not in out, repr(out)
+
+
+def test_hitl_renders_unrecognized_dict_as_compact_repr(capsys):
+    # gh #82: a dict with no known tool/human-readable key must still show its content
+    # (a compact repr), never the content-dropping `unknown`.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {"action_requests": [{"foo": "bar", "count": 3}]},
+        }
+    )
+    out = capsys.readouterr().out
+    assert "foo" in out and "bar" in out, repr(out)
+    assert "unknown" not in out, repr(out)
+
+
+def test_hitl_empty_action_requests_notes_missing_detail(capsys):
+    # gh #82: when the payload is dropped upstream (action_requests == []), the banner
+    # must not be silently contentless — it says no detail was provided so the operator
+    # knows they'd be approving blind.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk({"status": "interrupt", "interrupt": {"action_requests": []}})
+    out = capsys.readouterr().out
+    assert "Action Required" in out, repr(out)
+    assert "no action details" in out, repr(out)
+
+
+def test_hitl_empty_action_requests_surfaces_raw_value(capsys):
+    # gh #82: if a raw interrupt value survives on the frame even when action_requests
+    # is empty, render it rather than the "no detail" note.
+    c._QUIET = False
+    print_chunk._streaming_text = False
+    print_chunk(
+        {
+            "status": "interrupt",
+            "interrupt": {
+                "action_requests": [],
+                "value": "Approve deleting production database?",
+            },
+        }
+    )
+    out = capsys.readouterr().out
+    assert "Approve deleting production database?" in out, repr(out)
+
+
 def test_hitl_quiet_stdout_is_only_the_reply(tmp_path, monkeypatch):
     # gh #77 end-to-end: a HITL agent run with --no-interactive on the scriptable path
     # (single-shot + piped => quiet). stdout must be ONLY the agent's reply — no banner,


### PR DESCRIPTION
## What

Closes #82.

The HITL approval prompt rendered **nothing useful** for a *generic* LangGraph `interrupt(...)` — the canonical HITL primitive from the LangGraph docs. #69 wired the deepagents `ActionRequest` shape (tool name under `action`), but `print_chunk()`'s interrupt branch still assumed **every** interrupt was that shape:

- **Bare string** `interrupt("Approve deleting production database?")` — reaching the renderer as a string `action_request` — raised `'str' object has no attribute 'get'`. (A truly bare string is also JSON-decoded to `{}` and dropped by `langstage-core`'s AG-UI adapter, so `action_requests` arrives empty → a contentless banner.)
- **Non-`action` dict** `interrupt({"question": "..."})` → the CLI received `action_requests[0] = {"question": "..."}` but rendered `1. unknown`, discarding the `question` and every other non-`action`/`tool`/`args` key.

Either way the operator was asked to **approve or reject an action they could not see** — a real hazard when approval gates destructive work, not a cosmetic gap.

## Fix

A new `format_interrupt_request()` helper renders **any** payload actionably; the interrupt branch uses it:

- **bare string / scalar** → the value itself (no more `.get` crash);
- **dict without a recognized tool key** → its first human-readable field (`description`/`question`/`message`/`prompt`), else a compact JSON repr of the whole payload — instead of `unknown`;
- **structured `action`/`tool` + args** → **unchanged** (the #69 path).

When `action_requests` is empty, a surviving raw interrupt `value` is rendered if present; otherwise the banner reads `(no action details provided)` so it is never silently contentless.

Invariant: **the approval prompt must never ask the user to approve an action whose description it silently threw away.**

## Tests

Added to `tests/test_quiet_output.py` (fail-before / pass-after):

- `test_hitl_renders_bare_string_interrupt` — string shown, no crash;
- `test_hitl_renders_plain_dict_interrupt_content` — `question` surfaced, not `unknown`;
- `test_hitl_renders_unrecognized_dict_as_compact_repr` — compact repr, not `unknown`;
- `test_hitl_empty_action_requests_notes_missing_detail` — `(no action details provided)`;
- `test_hitl_empty_action_requests_surfaces_raw_value` — raw `value` rendered;
- `test_hitl_renders_structured_action_with_args_unchanged` — regression guard for the #69 path (passes on old code too).

Verified: the 5 bug-exercising tests fail on the pre-fix source and pass after; the regression guard passes on both. Full suite `115 passed` (was 109). `ruff check` + `ruff format --check` clean. Version bumped `0.6.18 → 0.6.19` with a CHANGELOG entry.

## Note

The full end-to-end bare-string case (Case A) also involves an upstream drop in `langstage-core`'s AG-UI adapter (a non-JSON string is decoded to `{}` before it reaches the CLI). That companion fix belongs in `langstage-core` and is out of scope here; this PR makes the CLI render the string whenever it survives to the renderer and stop presenting a blank banner when it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY