### PR TITLE
fix: interactive TTY reply erasure + HITL approval crash on non-TTY (Closes #84, #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.6.20 - 2026-07-18
+
+### Fixed
+- **The interactive conversation loop erased every agent reply on a real terminal (gh #84).** The
+  headline documented workflow — `langstage-cli --demo` / `-a my_agent.py:graph` — showed the user
+  their own prompt and the timing line with the agent's answer *missing*. `run_single_turn_agui()`
+  stops the spinner twice per turn: once on the first chunk (correct — that clears the "Thinking…"
+  animation) and again in a `finally`, which exists so a turn that streams no chunks at all still
+  clears the line instead of leaving a dangling "Thinking…". But `Spinner.stop()` ends with
+  `print("\r\033[2K")` — CR plus "erase entire line" — and the reply is streamed with `end=""` and
+  never terminated by a newline, so by the time the `finally` ran the cursor was parked on the
+  *reply's* last line and the second clear wiped it; `print_timing()` then wrote over where the reply
+  had been. A one-line reply — the common case — vanished entirely, and a multi-line reply lost its
+  last line, confirming a single current-line `CSI 2K`. This never reproduced in single-shot, piped,
+  or `--quiet` runs because those have no spinner (`spinner = None if _QUIET else …`), which is
+  exactly why the existing suite and the README one-liner looked healthy while the primary
+  interactive feature was unusable. `Spinner.stop()` is now idempotent — it emits its line-clear at
+  most once per run, reset on `start()` — so the useful first clear and the no-chunk safety net both
+  survive while the redundant second call becomes a no-op. Regression tests replay the emitted byte
+  stream through a minimal VT model (CR / `CSI 2K` / newline) and assert the reply is still on the
+  rendered screen, since `pty.fork()` is Unix-only and a stopped-twice assertion would only couple to
+  the implementation.
+- **Human-in-the-loop approval crashed with a cryptic `Error: (25, 'Inappropriate ioctl for device')`
+  on a non-TTY, after leaking the approval menu to stdout (gh #86).** In default interactive mode, an
+  agent raising a LangGraph `interrupt(...)` under a piped / CI / cron run — the scriptable context
+  the README actively promotes (`answer=$(langstage-cli -a my_agent.py:graph "do X")`) — hit
+  `get_key()`, whose Unix branch calls `termios.tcgetattr(fd)` with no `sys.stdin.isatty()` guard;
+  `tcgetattr` raises on a non-terminal, surfacing as a raw errno with no hint that `--no-interactive`
+  exists. Compounding it, `select_option()` printed the prompt, the `\033[?25l` cursor-hide escape,
+  and all four menu options to **stdout** *before* ever reading a key — corrupting the very stream a
+  piped single-shot run is contractually supposed to fill with only the agent's reply. The CLI
+  already detected a non-TTY for the quiet/scriptable decision; that detection simply was not applied
+  to the approval path. `handle_interrupt_input()` now checks stdin **before anything is printed** and
+  exits `1` with an actionable message on stderr (`Error: approval required but stdin is not a
+  terminal. / Re-run with --no-interactive to auto-approve pending actions.`), leaving stdout
+  untouched. It deliberately does *not* silently auto-approve: `interrupt()` is a request for human
+  review, so approving an action nobody saw is a worse failure than stopping — `--no-interactive`
+  remains the documented, explicit opt-in and its behavior is unchanged. Both call sites now share one
+  `_is_a_tty()` helper that never raises on a closed or replaced stream.
+
 ## 0.6.19 - 2026-07-16
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -225,6 +225,8 @@ class Spinner:
         self.thread = None
         self.frame_idx = 0
         self.start_time = None
+        # Whether stop() has already emitted its line-clear. See stop(). (gh #84)
+        self._stopped = False
 
     def _spin(self):
         """Run the spinner animation with elapsed time display."""
@@ -247,12 +249,32 @@ class Spinner:
     def start(self):
         """Start the spinner."""
         self.running = True
+        self._stopped = False
         self.start_time = time.time()
         self.thread = threading.Thread(target=self._spin, daemon=True)
         self.thread.start()
 
     def stop(self):
-        """Stop the spinner and clear the line."""
+        """Stop the spinner and clear its line. Idempotent — a second stop() is a
+        no-op (gh #84).
+
+        The line-clear below is ``CR`` + ``CSI 2K`` ("erase entire line"), which is
+        only ever correct while the cursor is still parked on the spinner's own
+        animated line. ``run_single_turn_agui()`` stops the spinner twice per turn:
+        once on the first chunk (correct — that clears "Thinking…") and again in its
+        ``finally``, which exists so a turn that streams NO chunks still clears the
+        line instead of leaving a dangling "Thinking…". But by the time the
+        ``finally`` runs on a normal turn the reply has been printed with ``end=""``
+        and no terminating newline, so the cursor sits on the *reply's* last line —
+        and the second clear erased it. On a real terminal the user saw their prompt
+        and the timing line with the agent's answer wiped out (a one-line reply
+        vanished entirely; a multi-line reply lost its last line). Guarding on
+        ``_stopped`` keeps the useful first clear and the no-chunk safety net while
+        making the redundant second call harmless.
+        """
+        if self._stopped:
+            return
+        self._stopped = True
         self.running = False
         if self.thread:
             self.thread.join(timeout=0.2)

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -56,6 +56,20 @@ BRIGHT_GREEN, BRIGHT_YELLOW = "\033[92m", "\033[93m"
 _QUIET = False
 
 
+def _is_a_tty(stream) -> bool:
+    """``stream.isatty()`` that never raises.
+
+    A replaced or closed stream (pytest capture, a detached service, a stream
+    swapped for a plain object) may lack ``isatty`` or raise ``ValueError`` on a
+    closed file. Treat anything unknowable as "not a terminal" — the safe default
+    for both the quiet/scriptable decision and the interactive-approval guard.
+    """
+    try:
+        return stream.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
 def _disable_ansi() -> None:
     """Blank every ANSI constant so nothing colorized reaches a pipe or file.
 
@@ -952,6 +966,24 @@ def handle_interrupt_input(num_actions: int = 1) -> List[Dict[str, Any]]:
     Returns:
         List of decision objects (one for each pending action)
     """
+    # The approval menu is arrow-key driven, so it needs a real terminal on stdin.
+    # Without this guard a piped / CI / cron run (`… "do X" </dev/null`) printed the
+    # cursor-hide escape and the whole menu to STDOUT — violating the contract that a
+    # piped single-shot run carries only the agent's reply — and then crashed inside
+    # get_key(): `termios.tcgetattr()` raises on a non-tty, surfacing as a cryptic
+    # `Error: (25, 'Inappropriate ioctl for device')`. Check BEFORE anything is
+    # printed, and fail loudly rather than auto-approving: an interrupt() is a request
+    # for human review, so silently approving an action nobody saw is worse than
+    # stopping. `--no-interactive` remains the documented way to opt into
+    # auto-approval, and the message points at it. (gh #86)
+    if not _is_a_tty(sys.stdin):
+        print(
+            "Error: approval required but stdin is not a terminal.\n"
+            "Re-run with --no-interactive to auto-approve pending actions.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     options = [
         "Approve all actions",
         "Reject all actions",
@@ -1702,10 +1734,7 @@ def main(
     # so the consumer gets only the reply/verdict (no spinner or "Loaded" line);
     # --quiet forces it in a terminal. Color is additionally stripped whenever stdout
     # is not a TTY, matching well-behaved CLIs.
-    try:
-        _is_tty = sys.stdout.isatty()
-    except (AttributeError, ValueError):
-        _is_tty = False
+    _is_tty = _is_a_tty(sys.stdout)
     global _QUIET
     _QUIET = quiet or ((bool(message or prompt_file) or verify_agent) and not _is_tty)
     if _QUIET or not _is_tty:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.19"
+version = "0.6.20"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_interrupt_non_tty.py
+++ b/tests/test_interrupt_non_tty.py
@@ -1,0 +1,85 @@
+"""HITL approval on a non-TTY fails cleanly instead of crashing (gh #86).
+
+The arrow-key approval menu needs a real terminal. Run in the scriptable context the
+README promotes — a piped / CI / cron single-shot invocation with stdin not a tty —
+the CLI used to print the cursor-hide escape and the whole menu to **stdout** (the
+stream a script captures, contractually reply-only), then crash inside `get_key()`
+where `termios.tcgetattr()` raises on a non-tty, surfacing as a cryptic
+`Error: (25, 'Inappropriate ioctl for device')` and exit 1.
+
+The fix guards on `sys.stdin.isatty()` *before* anything is printed and exits with an
+actionable message pointing at `--no-interactive`. It deliberately does NOT
+auto-approve: `interrupt()` is a request for human review, and approving an action
+nobody saw would be a worse failure than stopping. `--no-interactive` stays the
+documented opt-in, and its behavior is unchanged (see test_no_interactive_approve.py).
+"""
+
+import textwrap
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_HITL_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+    from langchain_core.messages import AIMessage
+
+    def ask(state):
+        decision = interrupt({"action": "delete_file", "path": "/etc/hosts"})
+        return {"messages": [AIMessage(content=f"Decision was: {decision}")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("ask", ask)
+    g.add_edge(START, "ask")
+    g.add_edge("ask", END)
+    graph = g.compile(checkpointer=MemorySaver())
+    """
+)
+
+
+def _invoke(tmp_path, monkeypatch):
+    """One interactive (no --no-interactive) single-shot run whose stdin is not a
+    terminal — CliRunner's stdin is a buffer, exactly like `</dev/null` or a pipe."""
+    (tmp_path / "hitl_agent.py").write_text(_HITL_AGENT)
+    monkeypatch.chdir(tmp_path)
+    return CliRunner().invoke(main, ["-a", "hitl_agent.py:graph", "please act"])
+
+
+def test_non_tty_approval_exits_with_an_actionable_error(tmp_path, monkeypatch):
+    r = _invoke(tmp_path, monkeypatch)
+
+    assert r.exit_code != 0, f"a run that could not get approval must not exit 0: {r.output!r}"
+    assert "stdin is not a terminal" in r.stderr, r.stderr
+    # The message must name the escape hatch, not just describe the failure.
+    assert "--no-interactive" in r.stderr, r.stderr
+    # And it must be the clean message, not the raw termios errno.
+    assert "Inappropriate ioctl" not in r.output, r.output
+    assert "(25," not in r.output, r.output
+
+
+def test_non_tty_approval_leaks_nothing_to_stdout(tmp_path, monkeypatch):
+    """stdout is the machine-readable stream. The menu, its cursor escapes, and the
+    error itself must all stay off it."""
+    r = _invoke(tmp_path, monkeypatch)
+
+    assert r.stdout == "", f"stdout must stay clean for the pipe, got {r.stdout!r}"
+    # Belt and braces: the specific artifacts the old code emitted.
+    assert "\033[?25l" not in r.stdout  # cursor hide
+    assert "How would you like to proceed?" not in r.stdout
+    assert "Approve all actions" not in r.stdout
+
+
+def test_no_interactive_still_auto_approves_on_the_same_input(tmp_path, monkeypatch):
+    """The guard must not change the documented opt-in path: with --no-interactive
+    the identical non-tty run still approves, resumes, and exits 0."""
+    (tmp_path / "hitl_agent.py").write_text(_HITL_AGENT)
+    monkeypatch.chdir(tmp_path)
+
+    r = CliRunner().invoke(main, ["-a", "hitl_agent.py:graph", "please act", "--no-interactive"])
+    assert r.exit_code == 0, r.output
+    assert "Decision was:" in r.stdout
+    assert "stdin is not a terminal" not in r.output

--- a/tests/test_spinner_reply_survives.py
+++ b/tests/test_spinner_reply_survives.py
@@ -1,0 +1,189 @@
+"""The interactive (TTY) turn must not erase the agent's reply (gh #84).
+
+`run_single_turn_agui()` stops the spinner twice per turn: once on the first chunk
+(correct — that clears the "Thinking…" animation) and again in its `finally`.
+`Spinner.stop()` ends with `print("\\r\\033[2K")` — CR + "erase entire line" — and
+because the reply is streamed with `end=""` and never terminated by a newline, the
+cursor is still parked on the reply's last line when the `finally` runs. The second
+clear therefore wiped the reply: on a real terminal the user saw only their own
+prompt and the timing line.
+
+Testing this needs the *TTY* path, not the piped one: the spinner only exists when
+`_QUIET` is False (`cli.py`: `spinner = None if _QUIET else Spinner("Thinking")`),
+which is exactly why the piped/`--quiet` suites and the README one-liner never
+caught it. The issue's repro drives a real PTY and renders it through `pyte`, but
+`pty.fork()` is Unix-only. So instead of faking a terminal we assert on the thing a
+terminal actually consumes — the emitted byte stream — replaying it through the
+minimal VT model below (CR, CSI 2K, newline: the three sequences at issue). A test
+that merely counted `stop()` calls would couple to the implementation; these assert
+the rendered screen, which is the observable defect.
+"""
+
+import asyncio
+import contextlib
+import io
+
+import pytest
+
+from langstage_cli import cli
+from langstage_cli import agui_stream
+
+
+def render(raw: str) -> list[str]:
+    """Replay `raw` the way a VT terminal would and return the visible lines.
+
+    Models only what this bug turns on: `\\r` (cursor to column 0), `CSI 2K`
+    (erase entire line, cursor unmoved), `\\n` (next line), and overwrite-in-place
+    for printable characters. Every other CSI sequence (color, cursor show/hide) is
+    consumed without affecting the display, exactly as a terminal does.
+    """
+    lines = [""]
+    col = 0
+    i = 0
+    while i < len(raw):
+        if raw.startswith("\033[2K", i):
+            lines[-1] = ""  # erase entire line; cursor column is unchanged
+            i += 4
+            continue
+        if raw.startswith("\033[", i):  # any other CSI — skip to its final byte
+            j = i + 2
+            while j < len(raw) and not raw[j].isalpha():
+                j += 1
+            i = j + 1
+            continue
+        ch = raw[i]
+        i += 1
+        if ch == "\r":
+            col = 0
+        elif ch == "\n":
+            lines.append("")
+            col = 0
+        else:
+            line = lines[-1].ljust(col)
+            lines[-1] = line[:col] + ch + line[col + 1 :]
+            col += 1
+    return lines
+
+
+def _stream_of(*chunks):
+    """Build a stand-in for `agui_stream_updates` yielding the given chunks."""
+
+    async def _fake(agent, message, thread_id, resume=None):
+        for chunk in chunks:
+            yield chunk
+
+    return _fake
+
+
+def _run_turn(monkeypatch, *chunks) -> list[str]:
+    """Drive one interactive turn, capturing everything written to stdout (spinner
+    thread included) and returning the rendered screen."""
+    monkeypatch.setattr(agui_stream, "agui_stream_updates", _stream_of(*chunks))
+    assert cli._QUIET is False, "the spinner — and thus the bug — only exists on the TTY path"
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        duration, _ = asyncio.run(cli.run_single_turn_agui(object(), "hi", "t1"))
+        # The real loop prints the timing immediately after the turn; it is what
+        # scrolled over the erased reply, so keep it in the captured stream.
+        cli.print_timing(duration)
+    return render(buffer.getvalue())
+
+
+def test_single_line_reply_survives_the_turn(monkeypatch):
+    """A one-line reply — the common case — vanished entirely before the fix."""
+    screen = _run_turn(
+        monkeypatch,
+        {"status": "streaming", "chunk": "SENTINEL-REPLY-TEXT", "node": "agent"},
+        {"status": "complete"},
+    )
+    assert any("SENTINEL-REPLY-TEXT" in line for line in screen), (
+        f"the reply was erased from the rendered terminal; screen={screen!r}"
+    )
+    # And the spinner's own line is gone — the first stop() still does its job.
+    assert not any("Thinking" in line for line in screen), screen
+
+
+def test_multi_line_reply_keeps_its_last_line(monkeypatch):
+    """A multi-line reply lost only its LAST line — the single-line `CSI 2K`."""
+    screen = _run_turn(
+        monkeypatch,
+        {"status": "streaming", "chunk": "LINE-ONE\nLINE-TWO\nLINE-THREE-LAST", "node": "agent"},
+        {"status": "complete"},
+    )
+    for expected in ("LINE-ONE", "LINE-TWO", "LINE-THREE-LAST"):
+        assert any(expected in line for line in screen), (
+            f"{expected!r} was erased from the rendered terminal; screen={screen!r}"
+        )
+
+
+def test_no_line_clear_is_emitted_after_reply_text(monkeypatch):
+    """Byte-level invariant: once reply text has been written, no erase-line escape
+    may be emitted before a newline returns the cursor to a fresh line."""
+    monkeypatch.setattr(
+        agui_stream,
+        "agui_stream_updates",
+        _stream_of(
+            {"status": "streaming", "chunk": "SENTINEL-REPLY-TEXT", "node": "agent"},
+            {"status": "complete"},
+        ),
+    )
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        asyncio.run(cli.run_single_turn_agui(object(), "hi", "t1"))
+    raw = buffer.getvalue()
+
+    tail = raw[raw.index("SENTINEL-REPLY-TEXT") + len("SENTINEL-REPLY-TEXT") :]
+    dangerous = tail.split("\n")[0]  # only what lands on the reply's own line
+    assert "\033[2K" not in dangerous, (
+        f"a line-clear escape follows the reply on its own line: tail={tail!r}"
+    )
+
+
+def test_turn_with_no_chunks_still_clears_the_spinner_line(monkeypatch):
+    """The `finally` exists for the error/empty turn: when nothing streams, the
+    spinner was never stopped on a first chunk, so its line must still be cleared
+    rather than leaving a dangling "Thinking…" on screen."""
+    screen = _run_turn(monkeypatch)
+    assert not any("Thinking" in line for line in screen), (
+        f"a dangling spinner line was left on screen; screen={screen!r}"
+    )
+
+
+def test_spinner_stop_is_idempotent_and_clears_once(monkeypatch):
+    """Directly: the first stop() clears the line, a repeat stop() writes nothing."""
+    spinner = cli.Spinner("Thinking")
+    spinner.start()
+
+    first = io.StringIO()
+    with contextlib.redirect_stdout(first):
+        spinner.stop()
+    assert "\033[2K" in first.getvalue()
+
+    second = io.StringIO()
+    with contextlib.redirect_stdout(second):
+        spinner.stop()
+    assert second.getvalue() == "", "a repeat stop() must not emit another line-clear"
+
+    # A restarted spinner clears again — the guard is per-run, not permanent.
+    spinner.start()
+    third = io.StringIO()
+    with contextlib.redirect_stdout(third):
+        spinner.stop()
+    assert "\033[2K" in third.getvalue()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("abc", ["abc"]),
+        ("abc\r\033[2K", [""]),  # the bug's exact sequence erases the line
+        ("abc\ndef\r\033[2K", ["abc", ""]),  # ...only the current line
+        ("\033[36mabc\033[0m", ["abc"]),  # color is invisible chrome
+        ("ab\rX", ["Xb"]),  # CR overwrites in place
+    ],
+)
+def test_render_models_the_terminal(raw, expected):
+    """Guard the guard: the VT model must behave like a real terminal, or the
+    assertions above would be meaningless."""
+    assert render(raw) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.14"
+version = "0.6.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Two defects on the interactive/terminal surface, both invisible to the existing suite because it only exercises the piped/scriptable path. Version bump `0.6.19 -> 0.6.20` + CHANGELOG.

## #84 — the interactive loop erased every agent reply (blocker)

The headline documented workflow (`langstage-cli --demo`, `-a my_agent.py:graph`) showed the user their own prompt and the timing line **with the agent's answer gone**.

`run_single_turn_agui()` stops the spinner twice per turn: once on the first chunk (correct — that clears the `Thinking…` animation) and again in a `finally`, which exists so a turn streaming *no* chunks still clears the line rather than leaving a dangling `Thinking…`. But `Spinner.stop()` ends with `print("\r\033[2K")` — CR plus "erase entire line" — and the reply is streamed with `end=""` and never terminated by a newline. By the time the `finally` ran, the cursor sat on the **reply's** last line and the second clear wiped it; `print_timing()` then wrote over where the reply had been. A one-line reply vanished entirely; a multi-line reply lost only its last line, confirming a single current-line `CSI 2K`.

It never reproduced in single-shot/piped/`--quiet` runs because those have no spinner (`spinner = None if _QUIET else …`) — which is exactly why the suite and the README one-liner looked healthy while the primary interactive feature was unusable.

**Fix:** `Spinner.stop()` is now idempotent — it emits its line-clear at most once per run, reset on `start()`. The useful first clear and the no-chunk safety net both survive; the redundant second call is a no-op.

**Evidence** — real demo agent, real AG-UI stream, real `Spinner`, `_QUIET=False`, captured stdout replayed through a VT model:

```
BEFORE                          AFTER
  |                               |⏺ (demo agent) You said: remember the number 7
  |186ms                          |189ms
  |                               |
```

## #86 — HITL approval crashed on a non-TTY, after leaking the menu to stdout

With an agent raising a LangGraph `interrupt(...)` under a piped / CI / cron run — the scriptable context the README promotes (`answer=$(langstage-cli -a my_agent.py:graph "do X")`) — `get_key()`'s Unix branch called `termios.tcgetattr(fd)` with no `sys.stdin.isatty()` guard. `tcgetattr` raises on a non-terminal, surfacing as a cryptic `Error: (25, 'Inappropriate ioctl for device')` with no hint that `--no-interactive` exists.

Compounding it, `select_option()` printed the prompt, the `\033[?25l` cursor-hide escape, and all four menu options to **stdout** *before* ever reading a key — corrupting the stream a piped single-shot run is contractually supposed to fill with only the agent's reply.

**Before / after** (identical invocation, stdin not a terminal):

```
BEFORE   stdout: '\x1b[?25l\nHow would you like to proceed?\n  ❯ Approve all actions\n…'
         stderr: 'Error: [Errno 25] Inappropriate ioctl for device'
         exit 1

AFTER    stdout: ''
         stderr: 'Error: approval required but stdin is not a terminal.
                  Re-run with --no-interactive to auto-approve pending actions.'
         exit 1
```

**Fix:** `handle_interrupt_input()` checks stdin **before anything is printed** and exits `1` with an actionable message on stderr. Both call sites now share one `_is_a_tty()` helper that never raises on a closed or replaced stream, replacing `main()`'s inlined try/except.

**Why an error rather than auto-approve:** `interrupt()` is a request for human review, often gating destructive work (the issue's own repro is `delete_file /etc/hosts`). Silently approving an action nobody saw is a worse failure than stopping. `--no-interactive` remains the documented, explicit opt-in; a test asserts the identical non-tty input still auto-approves, resumes, and exits `0` under it.

## Testing

`128 passed` (was `115`; +13). Every new assertion was verified to fail against the pre-fix code and pass after.

**How #84 was tested given no PTY on Windows.** `pty.fork()` is Unix-only, so the issue's `pyte` repro cannot run here. A "stop() was called once" assertion would only couple to the implementation, so `tests/test_spinner_reply_survives.py` asserts on **the bytes a terminal actually consumes**: it captures stdout (spinner thread included) from a real `run_single_turn_agui()` turn with `_QUIET=False` — the exact condition that gates the spinner and therefore the bug — and replays it through a minimal VT model (CR, `CSI 2K`, newline; the three sequences at issue), then asserts the reply is still on the rendered screen. The VT model is itself unit-tested against known terminal behavior so the guard cannot silently rot. Pre-fix, the rendered screen is `['', '90ms', '']`.

Covered: single-line reply survives; multi-line reply keeps its last line; byte-level invariant that no line-clear follows reply text before a newline; a no-chunk turn still clears the spinner line; `stop()` idempotency incl. reset on restart.

Caveat, stated plainly: this exercises the real emission path and the real escape-sequence semantics, but it is **not** a real PTY. It would not catch a defect that depends on terminal behavior beyond CR / `CSI 2K` / newline. The end-to-end before/after above was produced through the real demo agent and real AG-UI adapter, not a stub.

For #86, `tests/test_interrupt_non_tty.py` runs under `CliRunner`, whose stdin is a buffer — the same non-tty condition as `</dev/null`. Note that pre-fix on Windows this test *hangs* rather than failing, because `get_key()` takes the `msvcrt.getch()` branch and blocks on a real console instead of raising `termios.error`. Pre-fix failure was therefore confirmed with `get_key()` patched to raise Unix's exact `OSError(25, 'Inappropriate ioctl for device')` — leaving the missing guard and the stdout-polluting menu completely unmodified — which failed 6 of the 7 assertions (output above) and passes all 7 after. On Linux/CI the test file fails pre-fix directly, no patch needed.

Closes #84
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
