### PR TITLE
fix: generic interrupt() resumes with the raw user value, not {"decisions"} (gh #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.26 - 2026-07-26
+
+### Fixed
+- **A generic `interrupt(value)` now resumes with the RAW value the user provides, so
+  `name = interrupt("What is your name?")` gets the answer back instead of an approval
+  envelope it never asked for (gh #99).** #82 / #95 fixed DISPLAYING a generic
+  `interrupt(...)`; this closes the matching RESUME gap. The CLI built the resume payload
+  unconditionally as `{"decisions": [...]}` — the deepagents tool-REVIEW protocol — and forwarded
+  it verbatim as `command.resume`, which becomes the return value of `interrupt()`. So the
+  canonical LangGraph "collect input from a human" pattern received
+  `{"decisions": [{"type": "approve"}]}` and produced the visibly wrong
+  `Hello, {'decisions': [{'type': 'approve'}]}!`; even "Provide custom decision (JSON)" wrapped the
+  typed value inside the envelope, leaving no workaround. The resume now branches on the same signal
+  #82/#95 use to render: a deepagents tool-review interrupt (an `action_request` dict keyed `action`,
+  or the legacy `tool`) keeps the `{"decisions": [...]}` envelope unchanged, while a generic / scalar
+  `interrupt(value)` — a bare string (the `"What is your name?"` form) or a plain dict without an
+  action key — resumes with the raw value the user enters, UNWRAPPED (JSON is parsed when it parses, so
+  a number / list / dict survives; otherwise the text is used verbatim as a string). Under
+  `--no-interactive`, where nobody can supply the requested value, a generic interrupt resumes with an
+  empty value rather than injecting a fake approval — keeping the "run to completion" contract without
+  handing the agent a decision it never mentioned.
+
 ## 0.6.25 - 2026-07-25
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -679,6 +679,27 @@ def _compact_repr(value: Any) -> str:
     return text if len(text) <= 120 else text[:120] + "..."
 
 
+def _is_generic_interrupt(action_requests: List[Any]) -> bool:
+    """Whether an interrupt is a generic/scalar ``interrupt(value)`` rather than a
+    deepagents tool-REVIEW interrupt — the same distinction #82/#95 draw when
+    RENDERING, applied to the RESUME (gh #99).
+
+    A deepagents/langchain ``ActionRequest`` is a dict keyed ``action`` (the #69
+    convention) or the legacy ``tool``; its contract is the tool-review protocol,
+    so it resumes with a ``{"decisions": [...]}`` envelope. Anything else — a bare
+    string / scalar (the canonical ``value = interrupt("What is your name?")``
+    form, which core surfaces as a single string action request), or a plain dict
+    without that key — is generic: its contract is "``interrupt`` returns exactly
+    what I was resumed with", so it must resume with the RAW value the user gives,
+    never a ``{"decisions": [...]}`` approval envelope it never asked for.
+    """
+    if not action_requests:
+        return True
+    return not all(
+        isinstance(a, dict) and (a.get("action") or a.get("tool")) for a in action_requests
+    )
+
+
 def format_result_preview(result: str) -> str:
     """Format a result preview with line count indicator."""
     if not result:
@@ -959,15 +980,22 @@ def select_option(options: List[str], prompt: str = "Select an option:") -> int:
         print("\033[?25h", end="")
 
 
-def handle_interrupt_input(num_actions: int = 1) -> List[Dict[str, Any]]:
+def handle_interrupt_input(num_actions: int = 1, is_generic: bool = False) -> Any:
     """
-    Handle user input for interrupt decisions using arrow key navigation.
+    Handle user input for an interrupt using arrow key navigation, returning the
+    value to resume the graph with (the ``command.resume`` payload).
 
     Args:
         num_actions: Number of pending tool calls that need decisions
+        is_generic: True for a generic/scalar ``interrupt(value)`` (gh #99), False
+            for a deepagents tool-REVIEW interrupt.
 
     Returns:
-        List of decision objects (one for each pending action)
+        For a deepagents tool-review interrupt, a ``{"decisions": [...]}`` envelope
+        (unchanged — the tool-review protocol). For a generic interrupt, the RAW
+        value the user provides, UNWRAPPED, so ``value = interrupt("What is your
+        name?")`` gets exactly that value back instead of a ``{"decisions": [...]}``
+        envelope it never asked for (gh #99).
     """
     # The approval menu is arrow-key driven, so it needs a real terminal on stdin.
     # Without this guard a piped / CI / cron run (`… "do X" </dev/null`) printed the
@@ -987,6 +1015,24 @@ def handle_interrupt_input(num_actions: int = 1) -> List[Dict[str, Any]]:
         )
         sys.exit(1)
 
+    if is_generic:
+        # A generic interrupt() asks for an arbitrary value, not tool approval, so
+        # "Approve/Reject" have no meaning and wrapping the answer in
+        # {"decisions": [...]} corrupts it (gh #99). Collect a raw value and resume
+        # with it UNWRAPPED. JSON is attempted first so a structured value (number,
+        # list, dict) survives; a non-JSON entry is used verbatim as a string — the
+        # canonical `value = interrupt("What is your name?")` case, where the user
+        # types `Alice` and the agent must receive `"Alice"`, not an envelope.
+        options = ["Provide a response", "Exit"]
+        choice = select_option(options, "How would you like to respond?")
+        if choice != 0:
+            sys.exit(0)
+        raw = input(make_prompt("❯", BLUE))
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+
     options = [
         "Approve all actions",
         "Reject all actions",
@@ -997,20 +1043,20 @@ def handle_interrupt_input(num_actions: int = 1) -> List[Dict[str, Any]]:
     choice = select_option(options, "How would you like to proceed?")
 
     if choice == 0:
-        # Return approve decision for each pending action
-        return [{"type": "approve"} for _ in range(num_actions)]
+        # Approve decision for each pending action
+        return {"decisions": [{"type": "approve"} for _ in range(num_actions)]}
     elif choice == 1:
-        # Return reject decision for each pending action
-        return [{"type": "reject"} for _ in range(num_actions)]
+        # Reject decision for each pending action
+        return {"decisions": [{"type": "reject"} for _ in range(num_actions)]}
     elif choice == 2:
         print("Enter your decision as JSON (will be applied to all actions):")
         json_str = input(make_prompt("❯", BLUE)).strip()
         try:
             decision = json.loads(json_str)
-            return [decision for _ in range(num_actions)]
+            return {"decisions": [decision for _ in range(num_actions)]}
         except json.JSONDecodeError as e:
             print(f"{RED}⏺ Invalid JSON: {e}{RESET}")
-            return [{"type": "reject"} for _ in range(num_actions)]
+            return {"decisions": [{"type": "reject"} for _ in range(num_actions)]}
     else:
         sys.exit(0)
 
@@ -1432,6 +1478,7 @@ async def run_single_turn_agui(
     while True:
         has_interrupt = False
         num_pending_actions = 0
+        is_generic_interrupt = False
         first_chunk = True
         # No spinner in quiet mode — its \r animation is terminal-only chrome that
         # would corrupt a piped reply. (gh #53)
@@ -1452,13 +1499,25 @@ async def run_single_turn_agui(
                     interrupt_data = chunk.get("interrupt", {})
                     action_requests = interrupt_data.get("action_requests", [])
                     num_pending_actions = len(action_requests) if action_requests else 1
+                    is_generic_interrupt = _is_generic_interrupt(action_requests)
         finally:
             if spinner:
                 spinner.stop()
 
         if has_interrupt and interactive:
-            decisions = handle_interrupt_input(num_pending_actions)
-            resume = {"decisions": decisions}
+            resume = handle_interrupt_input(num_pending_actions, is_generic=is_generic_interrupt)
+        elif has_interrupt and is_generic_interrupt:
+            # --no-interactive on a generic interrupt() (gh #99): there is no action
+            # to "approve", and resuming with a {"decisions": [...]} envelope would
+            # hand the agent an approval it never asked for (`Hello, {'decisions':
+            # [...]}!`). Nobody can supply the requested value non-interactively, so
+            # resume with an empty value — a value the agent could plausibly have
+            # received — keeping the "run to completion" contract without lying.
+            _status(
+                f"{DIM}Auto-resuming generic interrupt with an empty value "
+                f"(--no-interactive){RESET}"
+            )
+            resume = ""
         elif has_interrupt:
             # --no-interactive: auto-approve and resume so the agent runs to
             # completion (same behavior as the default path, gh #32).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.25"
+version = "0.6.26"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_generic_interrupt.py
+++ b/tests/test_generic_interrupt.py
@@ -1,0 +1,177 @@
+"""A generic ``interrupt(value)`` resumes with the RAW user value, not the
+tool-review ``{"decisions": [...]}`` envelope (gh #99).
+
+#82 / #95 fixed DISPLAYING a generic ``interrupt(...)`` payload. This is the next
+gap: the value the CLI RESUMED the graph with was ALWAYS ``{"decisions": [...]}``,
+regardless of what the interrupt asked for. So the canonical LangGraph "collect
+input from a human" pattern — ``name = interrupt("What is your name?")`` — got
+``{"decisions": [{"type": "approve"}]}`` back and produced the visibly wrong
+``Hello, {'decisions': [{'type': 'approve'}]}!``.
+
+The fix branches the RESUME on the same signal #82/#95 use to RENDER: a deepagents
+tool-review interrupt (dict keyed ``action``) keeps the ``{"decisions": [...]}``
+envelope; a generic/scalar ``interrupt(value)`` resumes with the raw value the user
+gives, UNWRAPPED.
+"""
+
+import io
+import textwrap
+from contextlib import redirect_stdout
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_cli import cli  # noqa: E402
+from langstage_cli.agui_stream import build_session_agent  # noqa: E402
+from langstage_cli.cli import _is_generic_interrupt, run_single_turn_agui  # noqa: E402
+
+# The canonical "ask a human for a value" agent from the issue: a node does
+# `name = interrupt("What is your name?")` and greets with it. Resuming must return
+# EXACTLY the value the user gave — `Hello, Alice!` — not an approval envelope.
+_INPUT_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+    from langchain_core.messages import AIMessage
+
+    def greet(state):
+        name = interrupt("What is your name?")
+        return {"messages": [AIMessage(content=f"Hello, {name}!")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("greet", greet)
+    g.add_edge(START, "greet")
+    g.add_edge("greet", END)
+    graph = g.compile(checkpointer=MemorySaver())
+    """
+)
+
+# A deepagents-style tool-REVIEW interrupt (dict keyed `action`) — the shape whose
+# contract IS the `{"decisions": [...]}` protocol, which the fix must not regress.
+_REVIEW_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+    from langchain_core.messages import AIMessage
+
+    def ask(state):
+        decision = interrupt({"action": "delete_file", "path": "/etc/hosts"})
+        return {"messages": [AIMessage(content=f"Resumed with: {decision}")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("ask", ask)
+    g.add_edge(START, "ask")
+    g.add_edge("ask", END)
+    graph = g.compile(checkpointer=MemorySaver())
+    """
+)
+
+
+def _build(source: str):
+    ns: dict = {}
+    exec(source, ns)
+    return build_session_agent(ns["graph"])
+
+
+def test_is_generic_interrupt_classifies_shapes():
+    # A deepagents ActionRequest (dict keyed `action`, or the legacy `tool`) is a
+    # tool review — NOT generic.
+    assert _is_generic_interrupt([{"action": "delete_file", "args": {}}]) is False
+    assert _is_generic_interrupt([{"tool": "legacy", "args": {}}]) is False
+    # A bare string / scalar (the `interrupt("What is your name?")` form) is generic.
+    assert _is_generic_interrupt(["What is your name?"]) is True
+    # A plain dict without an action/tool key is generic (no tool-review contract).
+    assert _is_generic_interrupt([{"question": "How old are you?"}]) is True
+    # An empty request has nothing to approve — treat as generic, never approve blind.
+    assert _is_generic_interrupt([]) is True
+    # A mixed batch is generic if ANY request isn't a real ActionRequest.
+    assert _is_generic_interrupt([{"action": "x"}, "free text"]) is True
+
+
+async def test_generic_interrupt_resumes_with_the_raw_user_value(monkeypatch):
+    agent = _build(_INPUT_AGENT)
+
+    # Simulate the interactive HITL menu: a real terminal, the user picks the single
+    # "Provide a response" option, and types `Alice`.
+    monkeypatch.setattr(cli, "_is_a_tty", lambda *a, **k: True)
+    monkeypatch.setattr(cli, "select_option", lambda *a, **k: 0)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "Alice")
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _elapsed, had_error = await run_single_turn_agui(agent, "hi", "t-generic", interactive=True)
+    out = buf.getvalue()
+
+    assert had_error is False, out
+    # The fix: interrupt("What is your name?") gets "Alice" back, UNWRAPPED.
+    assert "Hello, Alice!" in out, out
+    # The tool-review envelope must never leak into a generic interrupt's answer.
+    assert "decisions" not in out, out
+    assert "'type': 'approve'" not in out, out
+
+
+async def test_generic_interrupt_accepts_a_structured_json_value(monkeypatch):
+    # A user may type structured JSON; it survives as the parsed value, not a string
+    # and not an envelope. Here `interrupt("What is your name?")` returns the list
+    # `["Alice", "B"]`, so the greeting renders it verbatim.
+    agent = _build(_INPUT_AGENT)
+    monkeypatch.setattr(cli, "_is_a_tty", lambda *a, **k: True)
+    monkeypatch.setattr(cli, "select_option", lambda *a, **k: 0)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: '["Alice", "B"]')
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _elapsed, had_error = await run_single_turn_agui(
+            agent, "hi", "t-generic-json", interactive=True
+        )
+    out = buf.getvalue()
+    assert had_error is False, out
+    assert "Hello, ['Alice', 'B']!" in out, out
+    assert "decisions" not in out, out
+
+
+async def test_action_review_interrupt_still_resumes_with_decisions(monkeypatch):
+    # No regression on #82/#95: a deepagents tool-review interrupt keeps the
+    # {"decisions": [...]} envelope. The user picks "Approve all actions".
+    agent = _build(_REVIEW_AGENT)
+    monkeypatch.setattr(cli, "_is_a_tty", lambda *a, **k: True)
+    monkeypatch.setattr(cli, "select_option", lambda *a, **k: 0)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _elapsed, had_error = await run_single_turn_agui(
+            agent, "please act", "t-review", interactive=True
+        )
+    out = buf.getvalue()
+
+    assert had_error is False, out
+    # The approval envelope is exactly what a tool-review interrupt should get back.
+    assert "Resumed with:" in out, out
+    assert "decisions" in out, out
+    assert "approve" in out, out
+
+
+async def test_generic_interrupt_no_interactive_avoids_the_decisions_envelope():
+    # Under --no-interactive nobody can supply the requested value, so a generic
+    # interrupt resumes with an empty value — NOT a {"decisions": [...]} approval it
+    # never asked for. The graph still runs to completion (gh #99 / #32).
+    agent = _build(_INPUT_AGENT)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _elapsed, had_error = await run_single_turn_agui(
+            agent, "hi", "t-generic-auto", interactive=False
+        )
+    out = buf.getvalue()
+
+    assert had_error is False, out
+    assert "decisions" not in out, out
+    assert "Hello, {'decisions'" not in out, out
+    # Resumed with an empty value -> `Hello, !` (a value the agent could have asked for).
+    assert "Hello, !" in out, out

--- a/tests/test_no_interactive_approve.py
+++ b/tests/test_no_interactive_approve.py
@@ -12,6 +12,10 @@ from click.testing import CliRunner
 
 from langstage_cli.cli import main
 
+# A deepagents-style tool-REVIEW interrupt (dict keyed `action`) — the shape for
+# which "approve" is meaningful, so --no-interactive genuinely auto-approves it and
+# resumes with the {"decisions": [...]} envelope. (A generic interrupt() has no
+# action to approve; its --no-interactive path is covered in test_generic_interrupt.py.)
 _HITL_AGENT = textwrap.dedent(
     """
     from langgraph.graph import StateGraph, START, END
@@ -21,7 +25,7 @@ _HITL_AGENT = textwrap.dedent(
     from langchain_core.messages import AIMessage
 
     def ask(state):
-        decision = interrupt({"question": "Approve this action?"})
+        decision = interrupt({"action": "delete_file", "path": "/etc/hosts"})
         return {"messages": [AIMessage(content=f"Decision was: {decision}")]}
 
     g = StateGraph(MessagesState)
@@ -43,3 +47,5 @@ def test_no_interactive_auto_approves_and_resumes(tmp_path, monkeypatch):
     # node ran and rendered its content, instead of the interrupt being dropped.
     assert "Auto-approving" in r.output
     assert "Decision was:" in r.output
+    # A tool-review interrupt resumes with the approval envelope (gh #99 keeps this).
+    assert "approve" in r.output


### PR DESCRIPTION
## Problem

#82 and #95 fixed *displaying* a generic `interrupt(...)` payload. This closes the matching **resume** gap.

The CLI built the resume envelope unconditionally as `{"decisions": [...]}` — the deepagents/langchain tool-**review** protocol — and forwarded it verbatim as `command.resume`, which becomes the return value of `interrupt()`. So the canonical LangGraph "collect input from a human" pattern:

```python
name = interrupt("What is your name?")
return AIMessage(content=f"Hello, {name}!")
```

received `{"decisions": [{"type": "approve"}]}` and produced the visibly wrong `Hello, {'decisions': [{'type': 'approve'}]}!`. Even "Provide custom decision (JSON)" wrapped the typed value inside the envelope, so there was **no** workaround.

## Fix

Branch the **resume** on the same signal #82/#95 use to **render** (`_is_generic_interrupt`, mirroring `format_interrupt_request`):

- **deepagents tool-review interrupt** (an `action_request` dict keyed `action`, or legacy `tool`) → keeps the `{"decisions": [...]}` envelope, unchanged.
- **generic / scalar `interrupt(value)`** (a bare string like `"What is your name?"`, or a plain dict without an action key) → resumes with the **raw value the user enters, unwrapped**. JSON is parsed when it parses (so a number/list/dict survives); otherwise the text is used verbatim as a string.
- **`--no-interactive`** on a generic interrupt → resumes with an empty value rather than injecting a fake approval it never asked for, keeping the run-to-completion contract.

## Tests

New `tests/test_generic_interrupt.py` drives real agents through the CLI resume path:
- `interrupt("What is your name?")` resumed with `Alice` → `Hello, Alice!` (and no `decisions` envelope leaks).
- a structured JSON answer survives as the parsed value.
- a deepagents `action_requests` interrupt **still** resumes with `{"decisions": [...]}` (no #82/#95 regression).
- the `--no-interactive` generic path avoids the envelope.
- unit coverage of the `_is_generic_interrupt` classifier boundary.

`test_no_interactive_approve.py`'s fixture now uses a genuine tool-review interrupt so it keeps testing auto-*approve* precisely; the generic auto path is covered in the new file.

Full suite: **151 passed**. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B