### PR TITLE
Sessions (--continue/--resume) + init scaffold; fix show-config provenance & HITL resume warning (0.6.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.6.27 - 2026-07-31
+
+### Added
+- **First-class cross-invocation session persistence — `--continue` / `--resume` (gh #102).**
+  Every `langstage-cli` run used to be amnesiac: memory lived only for one process (an
+  in-memory checkpointer), so the second command in a workflow couldn't see the first.
+  The CLI now attaches a durable, per-workspace checkpointer **itself** — no user-supplied
+  saver, no graph edits — so a fresh run is persisted and a later run can resume it:
+  `--continue`/`-c` resumes the most recent session for the workspace (and starts fresh,
+  with a note, if there is none); `--resume <id>` resumes a specific thread (exact id or an
+  unambiguous prefix; a bare `--resume`, like `--list-sessions`, lists them); a plain run
+  starts a new-but-persisted session. `--continue` and `--resume` are mutually exclusive.
+  State lives at `~/.langstage/sessions/<workspace-hash>.sqlite` (honoring
+  `LANGSTAGE_CONFIG_HOME`; override the whole location with `LANGSTAGE_CLI_SESSIONS_DIR`),
+  with a small JSON index (thread id, timestamps, first-message snippet) driving `--continue`
+  and `--list-sessions`. Persistence is on by default (disable via `--no-persist`,
+  `LANGSTAGE_PERSIST=0`, or `[session] persist = false`); a graph that brings its own
+  checkpointer keeps it (yours always wins), and a pinned `[configurable] thread_id` now
+  genuinely persists across runs. Because the AG-UI streaming path is async-only — langgraph's
+  sync `SqliteSaver` raises `NotImplementedError` for the async checkpointer methods the graph
+  invokes — the durable saver is the async-native `AsyncSqliteSaver` over the same SQLite file,
+  opened and closed within each turn's own event loop (its aiosqlite connection can't cross
+  loops); `/status` surfaces persistence state and the store path. Adds a
+  `langgraph-checkpoint-sqlite` dependency.
+- **`langstage-cli init` scaffolds a runnable starter agent + `langstage.toml` (gh #104).**
+  Bridges the gap between `--demo` ("see the CLI work") and "run *my* graph": `init` writes a
+  minimal, immediately-runnable `my_agent.py` (the README's keyless stdlib `StateGraph`
+  example — needs only `langgraph`, a base dependency) plus a `langstage.toml` wired to it, so
+  the very next `langstage-cli "..."` runs the user's own graph with no `-a` and no
+  hand-editing. It refuses to overwrite an existing `my_agent.py` / `langstage.toml` unless
+  `--force` is passed, and prints exactly what it wrote plus the next step.
+
+### Fixed
+- **`--show-config` now attributes each merged TOML value to the file it ACTUALLY came from
+  (gh #101).** When a global `~/.langstage/config.toml` and a project `langstage.toml` were both
+  present and merged, the resolver stamped **every** TOML-sourced value with the last file it read
+  (the project file), so a value set only in the global config was mislabelled
+  `[toml (langstage.toml)]` — sending a user debugging "where did `workspace_root` come from?" to
+  the wrong file. Merge/precedence were always correct; only the displayed source filename lied.
+  The CLI now post-processes the resolved provenance, walking the same files in merge order
+  (project wins on conflicts) and relabelling each value with the highest-precedence file that
+  actually defines its key. A cli-local fix — it corrects the source map the shared resolver
+  produced without touching core.
+- **A free-text `interrupt()` resume no longer leaks an `ag_ui_langgraph` WARNING to the console
+  (gh #103).** On the interactive HITL path, answering a plain-string `interrupt(...)` with free
+  text made the bundled `ag_ui_langgraph` dependency log `failed to parse resume_input as JSON,
+  treating as string (...)` at WARNING on **every** response — an error-looking line printed right
+  above the (correct) answer, in default interactive mode, on the CLI's headline HITL feature. The
+  resumed value was always right; it was pure confusing noise. The CLI now installs a surgical
+  `logging.Filter` that drops **only** that one benign record on the emitting `ag_ui_langgraph`
+  logger during the interactive resume, so no other warning is ever hidden. cli-local by design —
+  the CLI owns its console UX, so no global logging filter lands in core.
+
 ## 0.6.26 - 2026-07-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ This launches an interactive conversation loop with your agent.
 # Keyless demo agent — no API key, no agent of your own
 langstage-cli --demo "Hello"
 
+# Scaffold a runnable starter agent + langstage.toml (then just run it)
+langstage-cli init
+
 # Send a message directly to your agent
 langstage-cli -a my_agent.py:graph "Hello, agent!"
 
@@ -88,7 +91,46 @@ langstage-cli --demo
 # Print the resolved configuration: each value, its source, and the
 # env var / langstage.toml key that sets it
 langstage-cli --show-config
+
+# Resume a previous conversation across separate invocations
+langstage-cli "remember: my name is Kedar"   # a fresh, PERSISTED session
+langstage-cli -c "what's my name?"            # continue the most recent session
+langstage-cli --list-sessions                 # list resumable sessions
+langstage-cli --resume <id>                   # resume a specific one
 ```
+
+## Getting started with your own agent
+
+```bash
+langstage-cli --demo "hi"     # see the CLI work, keyless
+langstage-cli init            # scaffold my_agent.py + langstage.toml (your own graph)
+langstage-cli "hi"            # runs MY agent — no -a, no hand-editing
+```
+
+`init` writes a minimal, immediately-runnable starter agent (the stdlib `StateGraph`
+example below — needs only `langgraph`, a base dependency) plus a `langstage.toml`
+pointing at it, so the next `langstage-cli "..."` runs *your* graph. It refuses to
+overwrite an existing `my_agent.py` / `langstage.toml` unless you pass `--force`.
+
+## Resuming a session
+
+Every invocation persists its conversation to a durable, per-workspace store so a later
+run can pick it up — the terminal-agent continuity of Claude Code / Codex / Aider,
+without you baking a checkpointer into your own graph:
+
+- `--continue` / `-c` — resume the **most recent** session for this workspace and keep
+  going. If there's no prior session, it just starts a fresh one.
+- `--resume <id>` — resume a **specific** session (ids come from `--list-sessions`; a
+  bare `--resume` also lists them). A short prefix works if it's unambiguous.
+- A plain run with no flag starts a **new** session that is still persisted, so it can be
+  continued later.
+
+State lives in `~/.langstage/sessions/<workspace-hash>.sqlite` (honoring
+`LANGSTAGE_CONFIG_HOME`; override the whole location with `LANGSTAGE_CLI_SESSIONS_DIR`).
+Persistence is on by default — disable it with `--no-persist`, `LANGSTAGE_PERSIST=0`, or
+`[session] persist = false` in `langstage.toml`. A graph that compiles in its **own**
+checkpointer keeps it (yours always wins); the CLI only supplies a durable one when your
+graph has none. A pinned `[configurable] thread_id` now genuinely persists across runs.
 
 ## Commands
 
@@ -165,7 +207,15 @@ Options:
   --show-config                   Print the resolved configuration and exit
   -q, --quiet                     Scriptable single-shot output: only the reply
   --verify                        Preflight the agent (one real turn); exit 0/1
+  -c, --continue                  Resume the most recent session for this workspace
+  --resume [ID]                   Resume a specific session (bare: list them)
+  --list-sessions                 List resumable sessions for this workspace
+  --persist/--no-persist          Persist this session so it can be continued (default: on)
+  --force                         For `init`: overwrite existing files
   --version                       Show the version and exit
+
+Subcommand:
+  init                            Scaffold my_agent.py + langstage.toml in the current dir
 ```
 
 ### Verifying an agent (CI gate)

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -6,6 +6,7 @@ Styled after Claude Code / nanocode.
 import asyncio
 import copy
 import json
+import logging
 import os
 import re
 import subprocess
@@ -13,6 +14,7 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -21,6 +23,7 @@ import click
 
 from langstage_core import apply_workspace, load_agent_spec
 from langstage_cli import config as config_module
+from langstage_cli import sessions
 
 # Platform-specific imports for keyboard input
 IS_WINDOWS = sys.platform == "win32"
@@ -110,6 +113,56 @@ def _status(msg: str) -> None:
 # `async_mode`, inert since ADR 0003 collapsed every turn onto the one async AG-UI
 # path (gh #88).
 _INERT_KEYS = ["host", "port", "debug", "title", "stream_mode", "async_mode"]
+
+# Sentinel value of a bare ``--resume`` (no id): list this workspace's sessions instead
+# of resuming one. Matches the click option's ``flag_value``. (gh #102)
+_RESUME_LIST_SENTINEL = "__LIST__"
+
+# On the interactive HITL path, answering a plain-string ``interrupt(...)`` with free
+# text makes the bundled ``ag_ui_langgraph`` dep log a benign WARNING on EVERY response
+# — "failed to parse resume_input as JSON, treating as string (...)" — right above the
+# correct answer. The resumed value is right; the line just looks like an error. Drop
+# ONLY that one record so no other ag_ui_langgraph warning is ever hidden. cli-local by
+# design: the CLI owns its console UX, so this stays out of core. (gh #103)
+_AGUI_RESUME_JSON_WARNING = "failed to parse resume_input as JSON"
+
+# The warning is emitted by ``logging.getLogger("ag_ui_langgraph.agent")`` (the module
+# ``__name__``). A logger-level filter is consulted ONLY for records ORIGINATING on that
+# logger — during propagation ancestor-logger filters are skipped — so the filter must
+# sit on the emitting child logger (verified empirically). The package logger is added
+# too, defensively, in case a future version emits on it directly.
+_AGUI_WARNING_LOGGERS = ("ag_ui_langgraph.agent", "ag_ui_langgraph")
+
+
+class _DropResumeJSONWarning(logging.Filter):
+    """A surgical filter that removes ONLY ag_ui_langgraph's resume-JSON warning (gh #103)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:  # noqa: BLE001 - a malformed record must never break logging
+            message = str(getattr(record, "msg", ""))
+        return _AGUI_RESUME_JSON_WARNING not in message
+
+
+@contextmanager
+def _quiet_agui_resume_json_warning():
+    """Drop ag_ui_langgraph's benign resume-JSON WARNING for the wrapped block (gh #103).
+
+    Installs the precise :class:`_DropResumeJSONWarning` filter on the emitting logger
+    for the duration and removes it after — so the noise is gone from the interactive
+    resume path while every OTHER warning still reaches the console.
+    """
+    filt = _DropResumeJSONWarning()
+    loggers = [logging.getLogger(name) for name in _AGUI_WARNING_LOGGERS]
+    for lg in loggers:
+        lg.addFilter(filt)
+    try:
+        yield
+    finally:
+        for lg in loggers:
+            lg.removeFilter(filt)
+
 
 # Spinner frames for thinking animation
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
@@ -544,7 +597,9 @@ def parse_agent_spec(agent_spec: str) -> Tuple[str, str]:
     return file_path, variable_name
 
 
-def load_graph(spec: str, default_graph_name: str = "graph"):
+def load_graph(
+    spec: str, default_graph_name: str = "graph", attach_default_checkpointer: bool = True
+):
     """
     Load a graph from either a file path or module path.
 
@@ -578,7 +633,11 @@ def load_graph(spec: str, default_graph_name: str = "graph"):
             graph_name = tail or default_graph_name
 
     graph = load_agent_spec(f"{path_or_module}:{graph_name}")
-    _ensure_checkpointer(graph)
+    # Skip the in-memory default when a durable per-workspace saver will be attached
+    # instead (session persistence, gh #102) — else build_agent's in-memory fallback
+    # would win and cross-invocation memory would be lost.
+    if attach_default_checkpointer:
+        _ensure_checkpointer(graph)
     return graph, graph_name
 
 
@@ -1170,6 +1229,14 @@ def cmd_status(args: str, context: Dict[str, Any]) -> Optional[str]:
     # so the value was reporting a distinction the runtime does not have (gh #88).
     print(f"  {DIM}Verbose:{RESET}     {'on' if verbose else 'off'}")
     print(f"  {DIM}CWD:{RESET}         {os.getcwd()}")
+    # Session persistence, when active (gh #102): so it's discoverable and honored-as-
+    # advertised (persistence on/off, durable store path).
+    session_info = config.get("_session_info")
+    if isinstance(session_info, dict) and session_info.get("persist"):
+        durable = session_info.get("durable")
+        print(f"  {DIM}Persist:{RESET}     on ({'durable' if durable else 'graph checkpointer'})")
+        if session_info.get("store"):
+            print(f"  {DIM}Store:{RESET}       {session_info['store']}")
     print()
     return None
 
@@ -1486,20 +1553,26 @@ async def run_single_turn_agui(
         if spinner:
             spinner.start()
         try:
-            async for chunk in agui_stream_updates(agent, message, thread_id, resume=resume):
-                if first_chunk:
-                    if spinner:
-                        spinner.stop()
-                    first_chunk = False
-                print_chunk(chunk, verbose=verbose)
-                if chunk.get("status") == "error":
-                    had_error = True
-                if chunk.get("status") == "interrupt":
-                    has_interrupt = True
-                    interrupt_data = chunk.get("interrupt", {})
-                    action_requests = interrupt_data.get("action_requests", [])
-                    num_pending_actions = len(action_requests) if action_requests else 1
-                    is_generic_interrupt = _is_generic_interrupt(action_requests)
+            # Silence ag_ui_langgraph's benign "failed to parse resume_input as JSON"
+            # WARNING that fires on a free-text interrupt() resume, so it never appears
+            # above the (correct) answer on the interactive HITL path. The filter is
+            # surgical — only that one record — so wrapping the whole turn is harmless
+            # (the warning can only fire on a resume pass anyway). (gh #103)
+            with _quiet_agui_resume_json_warning():
+                async for chunk in agui_stream_updates(agent, message, thread_id, resume=resume):
+                    if first_chunk:
+                        if spinner:
+                            spinner.stop()
+                        first_chunk = False
+                    print_chunk(chunk, verbose=verbose)
+                    if chunk.get("status") == "error":
+                        had_error = True
+                    if chunk.get("status") == "interrupt":
+                        has_interrupt = True
+                        interrupt_data = chunk.get("interrupt", {})
+                        action_requests = interrupt_data.get("action_requests", [])
+                        num_pending_actions = len(action_requests) if action_requests else 1
+                        is_generic_interrupt = _is_generic_interrupt(action_requests)
         finally:
             if spinner:
                 spinner.stop()
@@ -1533,6 +1606,40 @@ async def run_single_turn_agui(
     return time.time() - start_time, had_error
 
 
+async def _run_turn_persistent(
+    graph: Any,
+    sqlite_path: Path,
+    message: str,
+    thread_id: str,
+    interactive: bool,
+    verbose: bool,
+    *,
+    name: str,
+    session_config: Any,
+) -> tuple[float, bool]:
+    """Run ONE turn with a durable per-workspace SQLite checkpointer (gh #102).
+
+    The AG-UI streaming path is async-only, and langgraph's SYNC ``SqliteSaver`` raises
+    ``NotImplementedError`` for the async checkpointer methods the graph invokes — so the
+    durable saver here is the async-native ``AsyncSqliteSaver`` over the same SQLite file
+    (see the PR notes). Its aiosqlite connection is bound to the event loop it is opened
+    in and cannot cross loops, and the CLI runs each turn in its own ``asyncio.run``; so
+    the saver is opened and closed WITHIN this turn's loop, and the AG-UI agent is rebuilt
+    here so it wraps the graph with this turn's live checkpointer. Persistence is durable
+    regardless — the SQLite FILE is the store, keyed by ``thread_id`` — so reopening per
+    turn reads back every prior turn's state. The ``async with`` guarantees a clean
+    open/close even on Ctrl-C, so state is never corrupted.
+    """
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+    from langstage_cli.agui_stream import build_session_agent
+
+    async with AsyncSqliteSaver.from_conn_string(str(sqlite_path)) as saver:
+        graph.checkpointer = saver
+        agent = build_session_agent(graph, name=name, config=session_config)
+        return await run_single_turn_agui(agent, message, thread_id, interactive, verbose)
+
+
 def run_conversation_loop(
     graph,
     config: Dict[str, Any],
@@ -1543,6 +1650,8 @@ def run_conversation_loop(
     stream_mode: str = "updates",
     initial_message: Optional[str] = None,
     single_shot: bool = False,
+    persist_sqlite_path: Optional[Path] = None,
+    on_turn: Optional[Any] = None,
 ):
     """
     Run a continuous conversation loop with the LangGraph agent.
@@ -1589,11 +1698,36 @@ def run_conversation_loop(
     configurable.pop("thread_id", None)
     session_config = {"configurable": configurable} if configurable else None
 
-    try:
-        agui_agent = build_session_agent(graph, name=agent_name, config=session_config)
-    except RuntimeError as e:
-        _status(f"{RED}⏺ {e}{RESET}")
-        return
+    # When persisting (gh #102) the durable AsyncSqliteSaver must be opened inside each
+    # turn's own event loop (its aiosqlite connection can't cross loops), so the agent is
+    # (re)built per turn there — skip the once-per-session build below. Otherwise build it
+    # once, as before, so the in-memory checkpointer's within-session memory persists.
+    agui_agent = None
+    if persist_sqlite_path is None:
+        try:
+            agui_agent = build_session_agent(graph, name=agent_name, config=session_config)
+        except RuntimeError as e:
+            _status(f"{RED}⏺ {e}{RESET}")
+            return
+
+    def run_one(msg: str) -> tuple:
+        """Run one turn, persisting to the durable store when configured."""
+        if on_turn is not None:
+            on_turn(msg)  # bump the session index (updated timestamp / first-message snippet)
+        if persist_sqlite_path is not None:
+            return asyncio.run(
+                _run_turn_persistent(
+                    graph,
+                    persist_sqlite_path,
+                    msg,
+                    thread_id,
+                    interactive,
+                    verbose,
+                    name=agent_name,
+                    session_config=session_config,
+                )
+            )
+        return asyncio.run(run_single_turn_agui(agui_agent, msg, thread_id, interactive, verbose))
 
     # Process initial message if provided
     if initial_message:
@@ -1602,9 +1736,7 @@ def run_conversation_loop(
             print(f"{initial_message}")
             print()
 
-        duration, had_error = asyncio.run(
-            run_single_turn_agui(agui_agent, initial_message, thread_id, interactive, verbose)
-        )
+        duration, had_error = run_one(initial_message)
         if _QUIET:
             # Only the reply reached stdout (streamed with end=""); cap it with a
             # single newline so the piped output ends cleanly. No timing line. (gh #53)
@@ -1692,9 +1824,7 @@ def run_conversation_loop(
                 print()  # Space before response
 
             # Run the agent (AG-UI is the only streaming path since langstage-core 1.0)
-            duration, _ = asyncio.run(
-                run_single_turn_agui(agui_agent, user_input, thread_id, interactive, verbose)
-            )
+            duration, _ = run_one(user_input)
             if _QUIET:
                 # Scriptable path (gh #93): cap the streamed reply with a single
                 # newline and emit no `Nms` timing line — exactly what the quiet
@@ -1714,6 +1844,114 @@ def run_conversation_loop(
     # path so a piped consumer never sees a trailing `Goodbye!`, gh #93).
     if not _QUIET:
         print_goodbye()
+
+
+# The README's stdlib StateGraph example — needs only langgraph (a base dependency),
+# so `langstage-cli init` scaffolds a graph that runs keyless with zero extra installs.
+# This is the BYO-graph analogue of --demo: a real, user-OWNED graph the adopter edits,
+# not a bundled runner. (gh #104)
+_INIT_AGENT_PY = """\
+# my_agent.py — a minimal LangGraph agent, runnable keyless (needs only langgraph,
+# a base dependency of langstage-cli). Edit `respond` to build your own agent, or
+# swap the node for a model call (see the langstage-cli README).
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import MessagesState
+from langchain_core.messages import AIMessage
+
+
+def respond(state):
+    last = state["messages"][-1].content
+    return {"messages": [AIMessage(content=f"You said: {last}")]}
+
+
+g = StateGraph(MessagesState)
+g.add_node("respond", respond)
+g.add_edge(START, "respond")
+g.add_edge("respond", END)
+graph = g.compile()
+"""
+
+_INIT_TOML = """\
+# Written by `langstage-cli init`. Points the CLI at your agent so a bare
+# `langstage-cli "Hello!"` runs it — no -a needed.
+[agent]
+spec = "my_agent.py:graph"
+"""
+
+_INIT_AGENT_FILENAME = "my_agent.py"
+_INIT_TOML_FILENAME = "langstage.toml"
+
+
+def scaffold_init(target_dir: Path, force: bool = False) -> int:
+    """Scaffold a runnable starter agent + ``langstage.toml`` into ``target_dir`` (gh #104).
+
+    Writes ``my_agent.py`` (the README's keyless stdlib example) and a ``langstage.toml``
+    wired to it, so the very next ``langstage-cli "Hello!"`` runs the user's OWN graph
+    with no ``-a`` and no hand-editing — the missing rung between ``--demo`` ("see it
+    work") and "run my own graph". Refuses to clobber an existing file unless ``force``
+    (never silently overwrites a user's agent), printing exactly what it did. Returns a
+    process exit code: 0 on success, 1 if it refused because a file already exists.
+    """
+    agent_path = target_dir / _INIT_AGENT_FILENAME
+    toml_path = target_dir / _INIT_TOML_FILENAME
+
+    if not force:
+        existing = [p.name for p in (agent_path, toml_path) if p.exists()]
+        if existing:
+            _status(f"{RED}⏺ Error: refusing to overwrite existing {', '.join(existing)}.{RESET}")
+            _status(f"{DIM}Re-run with --force to overwrite.{RESET}")
+            return 1
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    agent_path.write_text(_INIT_AGENT_PY, encoding="utf-8")
+    toml_path.write_text(_INIT_TOML, encoding="utf-8")
+
+    print(f"{GREEN}✓{RESET} Wrote {_INIT_AGENT_FILENAME} and {_INIT_TOML_FILENAME}")
+    print(f'{DIM}Next:{RESET}  langstage-cli "Hello!"        # runs your new agent')
+    print(f"{DIM}      langstage-cli --verify       # preflight it (one real turn){RESET}")
+    return 0
+
+
+def _resolve_persist(flag: Optional[bool], toml_config: dict) -> bool:
+    """Resolve whether to persist this session: ``--persist/--no-persist`` flag >
+    ``LANGSTAGE_PERSIST`` env > ``[session] persist`` TOML > default ON (gh #102).
+
+    Default-on is what makes ``--continue`` useful: a fresh run leaves a session behind
+    to resume. ``--continue`` / ``--resume`` force it on regardless (handled by caller).
+    """
+    if flag is not None:
+        return flag
+    env = os.getenv("LANGSTAGE_PERSIST")
+    if env is not None and env != "":
+        return env.strip().lower() in ("1", "true", "yes", "on")
+    toml_val = config_module.get(toml_config, "session.persist")
+    if isinstance(toml_val, bool):
+        return toml_val
+    return True
+
+
+def _format_ts(ts: Any) -> str:
+    """Format an epoch timestamp for the session list; ``?`` if unparseable."""
+    try:
+        return time.strftime("%Y-%m-%d %H:%M", time.localtime(float(ts)))
+    except (TypeError, ValueError):
+        return "?"
+
+
+def _print_sessions(workspace: Path) -> None:
+    """Print this workspace's persisted sessions, most-recent first (gh #102)."""
+    rows = sessions.list_sessions(workspace)
+    if not rows:
+        print(f"{DIM}No sessions yet for this workspace.{RESET}")
+        print(f'{DIM}Run a turn (e.g. langstage-cli "hi") to start one.{RESET}')
+        return
+    print(f"\n{BOLD}{BRIGHT_CYAN}Sessions{RESET} {DIM}({workspace}){RESET}")
+    print(f"{DIM}{'─' * 40}{RESET}")
+    for tid, entry in rows:
+        when = _format_ts(entry.get("updated"))
+        first = entry.get("first_message") or f"{DIM}(no message yet){RESET}"
+        print(f"  {CYAN}{tid[:8]}{RESET}  {DIM}{when}{RESET}  {first}")
+    print(f"\n{DIM}Resume with:  langstage-cli --resume <id>  (or -c for the most recent){RESET}\n")
 
 
 @click.command()
@@ -1812,6 +2050,44 @@ def run_conversation_loop(
     "completed cleanly, non-zero otherwise. Catches a missing key / broken tool "
     "/ bad graph before you rely on it (e.g. in CI).",
 )
+@click.option(
+    "--continue",
+    "-c",
+    "continue_session",
+    is_flag=True,
+    default=False,
+    help="Resume the MOST RECENT session for this workspace and keep the "
+    "conversation going (cross-invocation memory). Starts fresh if there is none.",
+)
+@click.option(
+    "--resume",
+    "resume_id",
+    is_flag=False,
+    flag_value=_RESUME_LIST_SENTINEL,
+    default=None,
+    help="Resume a specific session by id (as shown by --list-sessions). Bare "
+    "--resume lists recent sessions for this workspace to pick from.",
+)
+@click.option(
+    "--list-sessions",
+    "list_sessions",
+    is_flag=True,
+    default=False,
+    help="List recent persisted sessions for this workspace and exit.",
+)
+@click.option(
+    "--persist/--no-persist",
+    "persist",
+    default=None,
+    help="Persist this session to a durable store so it can be continued later "
+    "(default: on; also LANGSTAGE_PERSIST / [session] persist in langstage.toml).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="For `init`: overwrite existing my_agent.py / langstage.toml (default: refuse).",
+)
 def main(
     message: Optional[str],
     agent_spec: Optional[str],
@@ -1826,6 +2102,11 @@ def main(
     show_config: bool,
     quiet: bool,
     verify_agent: bool,
+    continue_session: bool,
+    resume_id: Optional[str],
+    list_sessions: bool,
+    persist: Optional[bool],
+    force: bool,
 ):
     """
     Run a LangGraph agent from the command line.
@@ -1858,8 +2139,11 @@ def main(
         langstage-cli -a my_agent.py:graph
         langstage-cli -f ./prompt.md
         langstage-cli --demo "try it with no API key"
+        langstage-cli init                      # scaffold my_agent.py + langstage.toml
         langstage-cli --show-config
         langstage-cli --verify -a my_agent.py   # preflight one real turn; exit 0/1
+        langstage-cli "remember: I'm Kedar"     # persisted session
+        langstage-cli -c "what's my name?"      # continue the most recent session
     """
     # Windows consoles default to cp1252, where the spinner (Braille frames) and
     # status glyphs (✓ ⏺ —) raise UnicodeEncodeError — the documented
@@ -1889,6 +2173,18 @@ def main(
     )
     if _QUIET or not _is_tty:
         _disable_ansi()
+
+    # `langstage-cli init` — scaffold a runnable starter agent + langstage.toml, then
+    # exit. Handled here (before any agent/config resolution) because init needs
+    # neither: it just writes files into the current directory. (gh #104)
+    if message == "init":
+        sys.exit(scaffold_init(Path.cwd(), force=force))
+
+    # --continue and --resume are mutually exclusive — they name two different threads
+    # to resume, so passing both is a contradiction. (gh #102)
+    if continue_session and resume_id is not None:
+        _status(f"{RED}⏺ Error: --continue and --resume are mutually exclusive{RESET}")
+        sys.exit(1)
 
     if demo:
         if agent_spec:
@@ -2003,6 +2299,25 @@ def main(
         # cli chdirs into it only when it was, matching prior behavior.
         workspace_explicit = cfg.sources.get("workspace_root") != "default"
 
+        # ---- Session persistence (gh #102) ----
+        # The resolved workspace keys the per-workspace session store. Compute it from
+        # the same workspace_root the run uses (before apply_workspace's chdir, which
+        # fires only for an explicit root — so this is stable either way).
+        workspace = Path(cfg.workspace_root).expanduser().resolve()
+
+        # A bare --resume (or --list-sessions) just lists this workspace's sessions and
+        # exits — no agent needed.
+        if list_sessions or resume_id == _RESUME_LIST_SENTINEL:
+            _print_sessions(workspace)
+            return
+
+        # Persistence is on by default so a fresh run can be continued later; disable via
+        # --no-persist / LANGSTAGE_PERSIST=0 / [session] persist=false. --continue and
+        # --resume always imply it.
+        persist = _resolve_persist(persist, toml_config)
+        if continue_session or resume_id is not None:
+            persist = True
+
         # If no spec provided, try the default agent
         if not final_spec:
             default_agent_path = Path(__file__).parent.parent / "examples" / "agent.py"
@@ -2033,7 +2348,17 @@ def main(
         loading = None if _QUIET else Spinner("Loading agent")
         if loading:
             loading.start()
-        graph, final_graph_name = load_graph(final_spec, final_graph_name_default)
+        # Load WITHOUT the in-memory default so we can see whether the graph brought its
+        # OWN checkpointer. A user-supplied checkpointer always wins (same rule as the
+        # #38 in-memory default): we attach our durable per-workspace saver only when the
+        # graph has none AND persistence is on. Otherwise restore the #38 behavior below.
+        graph, final_graph_name = load_graph(
+            final_spec, final_graph_name_default, attach_default_checkpointer=False
+        )
+        had_user_checkpointer = getattr(graph, "checkpointer", None) is not None
+        use_durable = persist and not had_user_checkpointer
+        if not use_durable:
+            _ensure_checkpointer(graph)
         if loading:
             loading.stop()
             print(f"{GREEN}✓{RESET} {DIM}Loaded {final_spec}{RESET}")
@@ -2076,6 +2401,46 @@ def main(
             _snap_configurable if isinstance(_snap_configurable, dict) else None
         )
 
+        # ---- Resolve the session thread + wire up persistence (gh #102) ----
+        persist_sqlite_path: Optional[Path] = None
+        session_thread: Optional[str] = None
+        on_turn = None
+        if persist:
+            if continue_session:
+                session_thread = sessions.most_recent_thread(workspace)
+                if session_thread is None:
+                    _status(
+                        f"{DIM}⏺ No prior session for this workspace — starting a fresh one.{RESET}"
+                    )
+            elif resume_id is not None:
+                session_thread = sessions.resolve_thread(workspace, resume_id)
+                if session_thread is None:
+                    _status(
+                        f"{RED}⏺ Error: no session matching '{resume_id}' "
+                        f"for this workspace.{RESET}"
+                    )
+                    _status(f"{DIM}Run --list-sessions to see available sessions.{RESET}")
+                    sys.exit(1)
+            if session_thread is None:
+                # Fresh persisted session: honour a pinned [configurable] thread_id if the
+                # user set one (now it actually persists across runs — closing the "I
+                # pinned a thread and it still forgot" gap), else the fresh uuid above.
+                session_thread = config_dict["configurable"]["thread_id"]
+            config_dict["configurable"]["thread_id"] = session_thread
+            sessions.record_session(workspace, session_thread, first_message=message)
+            if use_durable:
+                persist_sqlite_path = sessions.db_path(workspace)
+
+            def on_turn(msg: str) -> None:  # bump index recency + first-message snippet
+                sessions.touch_session(workspace, session_thread, first_message=msg)
+
+            config_dict["_session_info"] = {
+                "persist": True,
+                "durable": use_durable,
+                "store": str(persist_sqlite_path) if persist_sqlite_path else None,
+                "thread": session_thread,
+            }
+
         # Extract agent name and description from graph object
         agent_name = get_agent_name(graph)
         agent_description = get_agent_description(graph)
@@ -2094,6 +2459,8 @@ def main(
             stream_mode=final_stream_mode,
             initial_message=message,
             single_shot=bool(message),
+            persist_sqlite_path=persist_sqlite_path,
+            on_turn=on_turn,
         )
         if turn_had_error:
             sys.exit(1)

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -16,7 +16,12 @@ from pathlib import Path
 from typing import Any, ClassVar, List, Optional, Tuple
 
 from langstage_core.host import HostConfig, load_toml_config
-from langstage_core.host.config import _warn_legacy_env, _warned_legacy_env
+from langstage_core.host.config import (
+    _get_dotted,
+    _read_toml,
+    _warn_legacy_env,
+    _warned_legacy_env,
+)
 
 
 class ConfigError(Exception):
@@ -130,4 +135,44 @@ class CodeConfig(HostConfig):
             # signal a real user actually sees (the stderr note) would name a variable
             # absent from their environment, defeating the deprecation nudge (gh #73).
             _warned_legacy_env.add("DEEPAGENT_AGENT_SPEC")
-        return super().resolve(env=env, **kwargs)
+        obj = super().resolve(env=env, **kwargs)
+        _correct_toml_source_file_labels(obj)
+        return obj
+
+
+def _correct_toml_source_file_labels(cfg: HostConfig) -> None:
+    """Re-attribute each TOML-sourced value to the file it ACTUALLY came from (gh #101).
+
+    ``HostConfig.resolve`` stamps every ``toml``-sourced value with the LAST TOML
+    path it read (``toml_paths[-1]``) — which, when a global ``~/.langstage/config.toml``
+    and a project ``langstage.toml`` are both present and merged, is always the project
+    file. So a value set ONLY in the global config was mislabelled ``[toml (langstage.toml)]``,
+    sending a user debugging "where did ``workspace_root`` come from?" to the wrong file.
+    Merge/precedence were always correct; only the displayed source filename lied.
+
+    This walks the same files the resolver merged (global first, project last — project
+    wins on conflicts) and relabels each field's source with the highest-precedence file
+    that actually DEFINES its dotted key, so the source column names the real origin.
+    A cli-local fix: it post-processes the ``_sources`` map the shared resolver produced,
+    without touching core.
+    """
+    sources = getattr(cfg, "_sources", None)
+    toml_paths = getattr(cfg, "_toml_paths", None)
+    if not sources or not toml_paths:
+        return
+    toml_map = type(cfg)._toml_map()
+    # Read each merged file once; a value's winning file is the LAST (highest-precedence)
+    # one that defines its dotted key, mirroring the deep-merge's project-wins order.
+    per_file = [(path, _read_toml(path)) for path in toml_paths]
+    for name, origin in list(sources.items()):
+        if not origin.startswith("toml"):
+            continue
+        dotted = toml_map.get(name)
+        if dotted is None:
+            continue
+        winning: Optional[Path] = None
+        for path, data in per_file:
+            if _get_dotted(data, dotted) is not None:
+                winning = path
+        if winning is not None:
+            sources[name] = f"toml ({winning.name})"

--- a/langstage_cli/sessions.py
+++ b/langstage_cli/sessions.py
@@ -1,0 +1,174 @@
+"""Cross-invocation session persistence for langstage-cli (gh #102).
+
+Claude-Code-style continuity at the terminal: a plain ``langstage-cli "..."`` run
+persists its conversation so a later ``langstage-cli --continue`` (or ``--resume
+<id>``) can pick it back up — WITHOUT the user baking a durable checkpointer into
+their own graph. The CLI owns the store; any ``CompiledGraph`` (including ``--demo``)
+becomes resumable.
+
+Two pieces live here:
+
+* **The durable store location.** State is a per-workspace SQLite file under the
+  config home — ``<config-home>/sessions/<workspace-hash>.sqlite`` — where the config
+  home honours ``LANGSTAGE_CONFIG_HOME`` (then legacy ``DEEPAGENTS_CONFIG_HOME``),
+  defaulting to ``~/.langstage``. A dedicated ``LANGSTAGE_CLI_SESSIONS_DIR`` overrides
+  the whole sessions directory (used to keep tests hermetic). Keying by the resolved
+  workspace path matches how the CLI already resolves its workspace, so two projects
+  never share a thread namespace. The *checkpointer itself* is attached by the CLI at
+  run time (an ``AsyncSqliteSaver`` over this file) — see ``cli.py``.
+
+* **A small session index** (a JSON sidecar next to the sqlite file) mapping each
+  ``thread_id`` to ``created`` / ``updated`` timestamps and a snippet of the first user
+  message, so ``--resume <id>`` can target one, ``--list-sessions`` can show them, and
+  ``--continue`` can pick the most-recently-updated thread.
+"""
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Env override for the whole sessions directory. Primarily a hermeticity lever (tests
+# point it at a temp dir); a user could also relocate the store with it. Deliberately
+# separate from LANGSTAGE_CONFIG_HOME so pointing it at a temp dir never perturbs config
+# resolution.
+_SESSIONS_DIR_ENV = "LANGSTAGE_CLI_SESSIONS_DIR"
+
+_SNIPPET_MAX = 60
+
+
+def _config_home() -> Path:
+    """The LangStage config home — ``LANGSTAGE_CONFIG_HOME`` (then legacy
+    ``DEEPAGENTS_CONFIG_HOME``), else ``~/.langstage``. Mirrors core's own resolution
+    so sessions live beside the config the CLI already reads."""
+    override = os.getenv("LANGSTAGE_CONFIG_HOME") or os.getenv("DEEPAGENTS_CONFIG_HOME")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".langstage"
+
+
+def sessions_dir() -> Path:
+    """Directory holding every workspace's session store + index."""
+    override = os.getenv(_SESSIONS_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return _config_home() / "sessions"
+
+
+def workspace_key(workspace: Path) -> str:
+    """A stable, filesystem-safe key for a resolved workspace path.
+
+    A short SHA-256 hex of the absolute path: stable across runs, collision-safe in
+    practice, and never leaks the path into a filename.
+    """
+    resolved = str(Path(workspace).expanduser().resolve())
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:16]
+
+
+def db_path(workspace: Path) -> Path:
+    """Path to this workspace's SQLite checkpoint store (parent dir ensured)."""
+    d = sessions_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{workspace_key(workspace)}.sqlite"
+
+
+def _index_path(workspace: Path) -> Path:
+    return sessions_dir() / f"{workspace_key(workspace)}.index.json"
+
+
+def _snippet(text: Optional[str]) -> str:
+    """A one-line, length-capped preview of the first user message."""
+    if not text:
+        return ""
+    flat = " ".join(str(text).split())
+    return flat if len(flat) <= _SNIPPET_MAX else flat[:_SNIPPET_MAX] + "…"
+
+
+def load_index(workspace: Path) -> Dict[str, dict]:
+    """Load the workspace's ``thread_id -> {created, updated, first_message}`` map.
+
+    A missing or unreadable index degrades to empty — a corrupt sidecar must never
+    stop the CLI from running a turn.
+    """
+    path = _index_path(workspace)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    sessions = data.get("sessions") if isinstance(data, dict) else None
+    return sessions if isinstance(sessions, dict) else {}
+
+
+def _save_index(workspace: Path, sessions: Dict[str, dict]) -> None:
+    path = _index_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps({"sessions": sessions}, indent=2), encoding="utf-8")
+    tmp.replace(path)  # atomic-ish swap so a crash mid-write can't corrupt the index
+
+
+def record_session(workspace: Path, thread_id: str, first_message: Optional[str] = None) -> None:
+    """Register a NEW thread in the index (no-op if it already exists).
+
+    Called when a fresh session starts, so ``--continue`` / ``--list-sessions`` can see
+    it even if the run later errors.
+    """
+    sessions = load_index(workspace)
+    if thread_id in sessions:
+        return
+    now = time.time()
+    sessions[thread_id] = {
+        "created": now,
+        "updated": now,
+        "first_message": _snippet(first_message),
+    }
+    _save_index(workspace, sessions)
+
+
+def touch_session(workspace: Path, thread_id: str, first_message: Optional[str] = None) -> None:
+    """Bump a thread's ``updated`` timestamp (creating the entry if missing).
+
+    ``first_message`` fills the snippet only if it is still empty — so the FIRST user
+    message of a session sticks, and ``--continue`` orders by real recency of use.
+    """
+    sessions = load_index(workspace)
+    entry = sessions.get(thread_id)
+    now = time.time()
+    if entry is None:
+        entry = {"created": now, "updated": now, "first_message": _snippet(first_message)}
+        sessions[thread_id] = entry
+    else:
+        entry["updated"] = now
+        if not entry.get("first_message") and first_message:
+            entry["first_message"] = _snippet(first_message)
+    _save_index(workspace, sessions)
+
+
+def most_recent_thread(workspace: Path) -> Optional[str]:
+    """The most-recently-updated thread id for this workspace, or ``None`` if none."""
+    sessions = load_index(workspace)
+    if not sessions:
+        return None
+    return max(sessions.items(), key=lambda kv: kv[1].get("updated", 0))[0]
+
+
+def resolve_thread(workspace: Path, ref: str) -> Optional[str]:
+    """Resolve a ``--resume`` reference to a full thread id.
+
+    Accepts an exact id or an unambiguous prefix (ids are UUIDs; ``--list-sessions``
+    shows short forms). Returns the full id, or ``None`` if it matches nothing / is
+    ambiguous.
+    """
+    sessions = load_index(workspace)
+    if ref in sessions:
+        return ref
+    matches = [tid for tid in sessions if tid.startswith(ref)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def list_sessions(workspace: Path) -> List[Tuple[str, dict]]:
+    """All sessions for this workspace, most-recently-updated first."""
+    sessions = load_index(workspace)
+    return sorted(sessions.items(), key=lambda kv: kv[1].get("updated", 0), reverse=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.26"
+version = "0.6.27"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,6 +34,11 @@ dependencies = [
     "langstage-core[agui]>=1.0.28",
     "click>=8.0.0",
     "python-dotenv",
+    # Durable, cross-invocation session persistence (--continue / --resume, gh #102).
+    # Ships langgraph's SQLite savers; the CLI uses the async-native AsyncSqliteSaver
+    # (which pulls in aiosqlite) because the AG-UI streaming path is async-only — the
+    # sync SqliteSaver raises NotImplementedError for the async checkpointer methods.
+    "langgraph-checkpoint-sqlite>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,40 @@ def _reset_cli_global_state():
     _cli._QUIET = saved_quiet
     for name, value in saved_ansi.items():
         setattr(_cli, name, value)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_sessions(tmp_path, monkeypatch):
+    """Redirect session persistence (gh #102) to a per-test temp dir.
+
+    Persistence is ON by default, so ANY test that runs a real turn through ``main()``
+    would otherwise write a session store under the real ``~/.langstage/sessions``.
+    Pointing ``LANGSTAGE_CLI_SESSIONS_DIR`` at a temp dir keeps the whole suite hermetic
+    and off the developer's home — without touching config resolution (it's a dedicated
+    env var, distinct from ``LANGSTAGE_CONFIG_HOME``).
+    """
+    monkeypatch.setenv("LANGSTAGE_CLI_SESSIONS_DIR", str(tmp_path / "_sessions"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_published_workspace():
+    """Undo ``apply_workspace``'s env publishing between tests.
+
+    ``apply_workspace`` (ADR 0005) exports the resolved workspace as
+    ``LANGSTAGE_WORKSPACE_ROOT`` / ``DEEPAGENT_WORKSPACE_ROOT`` in ``os.environ`` — a
+    real product behavior, but it bypasses monkeypatch, so a test that runs a turn leaks
+    a workspace path (often a since-deleted temp dir) into the next test, corrupting its
+    config resolution / chdir. Snapshot and restore those two vars around every test.
+    """
+    import os
+
+    names = ("LANGSTAGE_WORKSPACE_ROOT", "DEEPAGENT_WORKSPACE_ROOT")
+    saved = {name: os.environ.get(name) for name in names}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/tests/test_hitl_resume_warning.py
+++ b/tests/test_hitl_resume_warning.py
@@ -1,0 +1,108 @@
+"""Answering a plain-string ``interrupt()`` must NOT leak ag_ui_langgraph's benign
+"failed to parse resume_input as JSON" WARNING to the console (gh #103).
+
+On the interactive HITL path, every free-text response to a plain-string
+``interrupt(...)`` made the bundled ``ag_ui_langgraph`` dep log an error-looking
+WARNING right above the (correct) answer. The value was always right; the line was
+pure confusing noise. The CLI drops ONLY that one record, surgically, so no other
+warning is ever hidden — and it stays cli-local (the CLI owns its console UX).
+"""
+
+import io
+import logging
+import textwrap
+from contextlib import redirect_stdout
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_cli import cli  # noqa: E402
+from langstage_cli.agui_stream import build_session_agent  # noqa: E402
+from langstage_cli.cli import _DropResumeJSONWarning, run_single_turn_agui  # noqa: E402
+
+# The issue's canonical plain-string interrupt agent: a node does
+# `answer = interrupt("What is your favorite color?")` and echoes it back.
+_HITL_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.types import interrupt
+    from langchain_core.messages import AIMessage
+
+    def ask(state):
+        answer = interrupt("What is your favorite color?")
+        return {"messages": [AIMessage(content=f"You chose: {answer}")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("ask", ask)
+    g.add_edge(START, "ask")
+    g.add_edge("ask", END)
+    graph = g.compile(checkpointer=MemorySaver())
+    """
+)
+
+
+class _Capture(logging.Handler):
+    """Records the messages of every log record that reaches it."""
+
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+async def test_free_text_resume_does_not_leak_the_json_parse_warning(monkeypatch):
+    ns: dict = {}
+    exec(_HITL_AGENT, ns)
+    agent = build_session_agent(ns["graph"])
+
+    # Simulate the interactive HITL menu: a real terminal, user picks "Provide a
+    # response", and types free text `blue` (not valid JSON — the noisy case).
+    monkeypatch.setattr(cli, "_is_a_tty", lambda *a, **k: True)
+    monkeypatch.setattr(cli, "select_option", lambda *a, **k: 0)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "blue")
+
+    # Capture anything the emitting logger would send to the console.
+    logger = logging.getLogger("ag_ui_langgraph.agent")
+    cap = _Capture()
+    old_level = logger.level
+    logger.setLevel(logging.WARNING)
+    logger.addHandler(cap)
+
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            _elapsed, had_error = await run_single_turn_agui(
+                agent, "start", "t-color", interactive=True
+            )
+    finally:
+        logger.removeHandler(cap)
+        logger.setLevel(old_level)
+
+    out = buf.getvalue()
+    assert had_error is False, out
+    # The resumed value is still correct...
+    assert "You chose: blue" in out, out
+    # ...and the benign warning was dropped at the logger, never reaching a handler.
+    assert not any("failed to parse resume_input as JSON" in m for m in cap.messages), cap.messages
+
+
+def test_filter_drops_only_the_resume_warning():
+    # Unit-level guard that the filter is surgical: it drops the one benign record and
+    # lets every other warning through.
+    filt = _DropResumeJSONWarning()
+
+    def record(msg: str) -> logging.LogRecord:
+        return logging.LogRecord(
+            "ag_ui_langgraph.agent", logging.WARNING, __file__, 1, msg, None, None
+        )
+
+    assert (
+        filt.filter(record("failed to parse resume_input as JSON, treating as string (x)")) is False
+    )
+    assert filt.filter(record("some other important warning")) is True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,43 @@
+"""`langstage-cli init` scaffolds a runnable starter agent + langstage.toml (gh #104).
+
+`--demo` proves the CLI works; `init` proves *your graph* works — the missing rung
+between "see it work" and "run my own graph". It writes a keyless stdlib agent and a
+langstage.toml wired to it, so the very next `langstage-cli "..."` runs the user's own
+graph with no -a and no hand-editing. It never clobbers existing files without --force.
+"""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_init_scaffolds_files_that_load_and_run(monkeypatch, tmp_path):
+    # Isolate the global config so the scaffolded project langstage.toml is what runs.
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        res = r.invoke(main, ["init"])
+        assert res.exit_code == 0, res.output
+        assert (Path(fs) / "my_agent.py").exists()
+        assert (Path(fs) / "langstage.toml").exists()
+        assert "Wrote my_agent.py and langstage.toml" in res.output
+
+        # The scaffold then loads + runs under the CLI with no -a needed.
+        run = r.invoke(main, ["--no-interactive", "Hello!"])
+        assert run.exit_code == 0, run.output
+        assert "You said: Hello!" in run.output
+
+
+def test_init_refuses_to_overwrite_without_force(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    r = CliRunner()
+    with r.isolated_filesystem():
+        assert r.invoke(main, ["init"]).exit_code == 0
+        # A second init refuses (non-zero) rather than clobbering the user's agent.
+        second = r.invoke(main, ["init"])
+        assert second.exit_code != 0
+        assert "refusing to overwrite" in second.output
+        # ...unless --force is passed.
+        assert r.invoke(main, ["init", "--force"]).exit_code == 0

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,166 @@
+"""First-class cross-invocation session persistence: --continue / --resume (gh #102).
+
+Every invocation used to start amnesiac (an in-memory checkpointer thrown away at
+process exit). The CLI now attaches a durable per-workspace SQLite checkpointer itself
+so a fresh run is persisted and a later `--continue` (most recent) or `--resume <id>`
+(a specific thread) picks the conversation back up — no user-supplied checkpointer, no
+graph edits. Tests are hermetic: the autouse `_hermetic_sessions` fixture points the
+session store at a temp dir, and each test isolates the global config home.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+pytest.importorskip("langgraph.checkpoint.sqlite.aio")
+
+from langstage_cli import sessions  # noqa: E402
+from langstage_cli.cli import main  # noqa: E402
+
+# A keyless, deterministic agent that ECHOES prior state: it reports the FIRST human
+# message it can see. A second invocation that still reports the first turn's fact proves
+# memory persisted across processes (separate SqliteSaver opens over the same file).
+_ECHO_AGENT = textwrap.dedent(
+    """
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.graph.message import MessagesState
+    from langchain_core.messages import AIMessage
+
+    def respond(state):
+        first = ""
+        for m in state["messages"]:
+            if getattr(m, "type", "") == "human":
+                first = m.content
+                break
+        return {"messages": [AIMessage(content=f"first fact: {first}")]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("respond", respond)
+    g.add_edge(START, "respond")
+    g.add_edge("respond", END)
+    graph = g.compile()
+    """
+)
+
+
+def _setup(runner_fs: str, monkeypatch, tmp_path) -> None:
+    """Write the echo agent + langstage.toml into the isolated fs and isolate config."""
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    (Path(runner_fs) / "echo_agent.py").write_text(_ECHO_AGENT)
+    (Path(runner_fs) / "langstage.toml").write_text('[agent]\nspec = "echo_agent.py:graph"\n')
+
+
+def test_continue_recalls_the_earlier_turn(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        # Turn 1 (fresh, persisted): establish a fact.
+        one = r.invoke(main, ["--no-interactive", "my name is Kedar"])
+        assert one.exit_code == 0, one.output
+        assert "first fact: my name is Kedar" in one.output
+
+        # Turn 2 (--continue): a SEPARATE invocation still sees the earlier turn's
+        # content — memory persisted across processes via the durable store.
+        two = r.invoke(main, ["-c", "--no-interactive", "what did I say?"])
+        assert two.exit_code == 0, two.output
+        assert "first fact: my name is Kedar" in two.output
+
+
+def test_fresh_run_starts_empty(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        r.invoke(main, ["--no-interactive", "my name is Kedar"])
+        # A run WITHOUT --continue is a brand-new session: it can only see its own turn.
+        fresh = r.invoke(main, ["--no-interactive", "a totally new topic"])
+        assert fresh.exit_code == 0, fresh.output
+        assert "first fact: a totally new topic" in fresh.output
+
+
+def test_resume_targets_a_specific_thread(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        r.invoke(main, ["--no-interactive", "session A fact"])  # session A
+        r.invoke(main, ["--no-interactive", "session B fact"])  # session B (most recent)
+
+        workspace = Path(fs).resolve()
+        rows = sessions.list_sessions(workspace)
+        a_tid = next(t for t, e in rows if e["first_message"] == "session A fact")
+
+        # --resume <id> continues THAT thread, even though B is the most recent.
+        res = r.invoke(main, ["--resume", a_tid, "--no-interactive", "back to A"])
+        assert res.exit_code == 0, res.output
+        assert "first fact: session A fact" in res.output
+
+
+def test_continue_with_no_prior_starts_fresh_without_error(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        # --continue with nothing to continue must NOT error — it starts fresh + notes it.
+        res = r.invoke(main, ["-c", "--no-interactive", "hello"])
+        assert res.exit_code == 0, res.output
+        assert "first fact: hello" in res.output
+        assert "No prior session" in res.output
+
+
+def test_continue_and_resume_are_mutually_exclusive(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        res = r.invoke(main, ["-c", "--resume", "abc", "--no-interactive", "hi"])
+        assert res.exit_code != 0
+        assert "mutually exclusive" in res.output
+
+
+def test_no_persist_disables_persistence(monkeypatch, tmp_path):
+    r = CliRunner()
+    with r.isolated_filesystem() as fs:
+        _setup(fs, monkeypatch, tmp_path)
+        r.invoke(main, ["--no-persist", "--no-interactive", "remember me"])
+        # Nothing was recorded, so --continue finds no prior session.
+        res = r.invoke(main, ["-c", "--no-interactive", "still here?"])
+        assert "No prior session" in res.output
+
+
+# ---- sessions module unit tests ----
+
+
+def test_sessions_index_records_and_resolves(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANGSTAGE_CLI_SESSIONS_DIR", str(tmp_path / "store"))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    sessions.record_session(ws, "thread-aaaa1111", first_message="hello world")
+    sessions.record_session(ws, "thread-bbbb2222", first_message="second one")
+
+    # most_recent is the last-updated; touch bumps it.
+    sessions.touch_session(ws, "thread-aaaa1111")
+    assert sessions.most_recent_thread(ws) == "thread-aaaa1111"
+
+    # exact + unambiguous-prefix resolution; ambiguous/unknown -> None.
+    assert sessions.resolve_thread(ws, "thread-bbbb2222") == "thread-bbbb2222"
+    assert sessions.resolve_thread(ws, "thread-aaaa") == "thread-aaaa1111"
+    assert sessions.resolve_thread(ws, "thread-") is None  # ambiguous
+    assert sessions.resolve_thread(ws, "nope") is None
+
+    # snippet of the first message is retained.
+    rows = dict(sessions.list_sessions(ws))
+    assert rows["thread-aaaa1111"]["first_message"] == "hello world"
+
+
+def test_sessions_are_keyed_per_workspace(monkeypatch, tmp_path):
+    monkeypatch.setenv("LANGSTAGE_CLI_SESSIONS_DIR", str(tmp_path / "store"))
+    ws1 = tmp_path / "ws1"
+    ws2 = tmp_path / "ws2"
+    ws1.mkdir()
+    ws2.mkdir()
+    sessions.record_session(ws1, "t-1", first_message="in ws1")
+    # A different workspace has its own, independent index.
+    assert sessions.most_recent_thread(ws2) is None
+    assert sessions.db_path(ws1) != sessions.db_path(ws2)

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -93,6 +93,32 @@ def test_show_config_omits_server_only_keys():
     assert re.search(r"^\s*agent_spec\s*=", r.output, re.MULTILINE), r.output
 
 
+def test_show_config_attributes_a_global_only_value_to_the_global_file(tmp_path, monkeypatch):
+    """gh #101: a value set ONLY in the global ~/.langstage/config.toml must be attributed
+    to the GLOBAL file in --show-config, not to the project langstage.toml.
+
+    Before the fix every toml-sourced value was stamped with the LAST file read (the
+    project file when both are merged), so ``workspace_root`` — set only globally — was
+    mislabelled ``[toml (langstage.toml)]`` and sent a debugging user to the wrong file.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    # workspace.root ONLY in the global config; agent.spec ONLY in the project config.
+    (home / "config.toml").write_text('[workspace]\nroot = "/tmp/GLOBAL_ONLY_DIR"\n')
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "langstage.toml").write_text('[agent]\nspec = "my_agent.py:graph"\n')
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(home))
+    monkeypatch.chdir(proj)
+
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    # The global-only value names the GLOBAL file (config.toml), not the project file.
+    assert re.search(r"workspace_root\s*=.*\[toml \(config\.toml\)\]", r.output), r.output
+    # The project-only value still names the project file.
+    assert re.search(r"agent_spec\s*=.*\[toml \(langstage\.toml\)\]", r.output), r.output
+
+
 def test_show_config_title_env_not_advertised_as_effective():
     """Setting LANGSTAGE_TITLE must not show up as an in-effect value on a surface
     that ignores it (it would mislead the user). (gh #36)"""

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -597,15 +606,29 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/b1/26fef7572c4fce0322740ef3fcee471510028355d4d4c1d800f0fd432d73/langgraph_checkpoint_sqlite-3.1.1.tar.gz", hash = "sha256:6fcb20db4c37ef7aad52f29b539eb98c38e2dad6fab7c2446a2a9db24f37a70e", size = 146805, upload-time = "2026-07-30T19:19:37.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b9/e458601a1718337839bcfeec9d1b27b8b16ce135be2bd50ed0395d33a878/langgraph_checkpoint_sqlite-3.1.1-py3-none-any.whl", hash = "sha256:8505c54c94a658080525d7e6780fdd4e0c078ff2566b30d399c02cc9f9af1c63", size = 40785, upload-time = "2026-07-30T19:19:36.424Z" },
 ]
 
 [[package]]
@@ -655,11 +678,12 @@ wheels = [
 
 [[package]]
 name = "langstage-cli"
-version = "0.6.20"
+version = "0.6.27"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "langstage-core", extra = ["agui"] },
     { name = "python-dotenv" },
 ]
@@ -687,7 +711,8 @@ requires-dist = [
     { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "fastapi", marker = "extra == 'dev'" },
     { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.14" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.0" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.28" },
     { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -699,14 +724,14 @@ provides-extras = ["dev", "agui"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.14"
+version = "1.0.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/30/fbdb059f95d45f1e01b7531c62f01bc9d1f9b99f1fe85a46577fecf949db/langstage_core-1.0.14.tar.gz", hash = "sha256:f8f12d4e7184b3ceefb9aefd360dc987c3521a898f507ee15713d3d90eb03c14", size = 240445, upload-time = "2026-07-08T14:40:41.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/23/e02b049512956aa0e955a6a2b3e4fb6e3902b97a143d7778b31fa07d4e56/langstage_core-1.0.31.tar.gz", hash = "sha256:00c2ba20002fc9abc4dd0e8ac514b6cb53ab43bff449eed355c9c7cfa468757c", size = 298577, upload-time = "2026-07-31T05:24:46.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/44/2e4c6f7f80ed7fdf322e669cba83b9afeb467e7eb69cdf9d298c335f79fd/langstage_core-1.0.14-py3-none-any.whl", hash = "sha256:236da4a2414d4c3b3b8811c1ca93e0e3a9fc4480b1d9a5b611b5e4d2e651b461", size = 60305, upload-time = "2026-07-08T14:40:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0b/a184122fe25c190329fc16587859daa196ad6a9558df5194e8a1f2569fdb/langstage_core-1.0.31-py3-none-any.whl", hash = "sha256:79059b68c696e0c04f3ba91383abd6053c9685450665b6255c9690b23626459f", size = 87388, upload-time = "2026-07-31T05:24:44.893Z" },
 ]
 
 [package.optional-dependencies]
@@ -1292,6 +1317,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ships **four cli-local** changes as one release (**0.6.27**): two features and two bug fixes. Full suite green (**164 passed**, +13 regression tests), `ruff check` + `ruff format --check` clean.

## #102 — first-class session persistence: `--continue` / `--resume` (feature, the big one)
Every invocation used to be amnesiac (an in-memory checkpointer thrown away at process exit). The CLI now attaches a **durable, per-workspace checkpointer itself** — no user-supplied saver, no graph edits:
- `--continue` / `-c` — resume the most recent session for this workspace (starts fresh, with a note, if there is none).
- `--resume <id>` — resume a specific thread (exact id or unambiguous prefix). A bare `--resume` (or `--list-sessions`) lists resumable sessions.
- A plain run starts a **new-but-persisted** session, so it can be continued later.
- `--continue` and `--resume` are mutually exclusive.

**Where state lives:** `~/.langstage/sessions/<workspace-hash>.sqlite` — under the config home, honoring `LANGSTAGE_CONFIG_HOME` (so it fits the CLI's existing config model), keyed by the resolved workspace path. A dedicated `LANGSTAGE_CLI_SESSIONS_DIR` overrides the whole location (also the test-hermeticity lever). A small JSON index (`<hash>.index.json`: thread id, created/updated timestamps, first-message snippet) drives `--continue` (most-recently-updated) and `--list-sessions`. Persistence is **on by default** (disable with `--no-persist`, `LANGSTAGE_PERSIST=0`, or `[session] persist = false`). A graph that compiles in its **own** checkpointer keeps it (yours always wins); a pinned `[configurable] thread_id` now genuinely persists across runs; `/status` surfaces persistence state + store path.

**Design note (a genuine fork, resolved and documented):** the issue suggested langgraph's **sync** `SqliteSaver`, but the CLI's only execution path is the **async** AG-UI adapter, and the sync saver raises `NotImplementedError` for the async checkpointer methods the graph invokes (verified). So the durable saver is the **async-native `AsyncSqliteSaver`** over the same SQLite file. Its aiosqlite connection is bound to the event loop it's opened in and can't cross loops, and the CLI runs each turn in its own `asyncio.run`, so the saver is opened/closed **within each turn's loop** (the agent is rebuilt there to wrap the graph with the live checkpointer). Persistence is durable regardless — the SQLite **file** is the store — so reopening per turn reads back every prior turn's state; `async with` guarantees a clean open/close even on Ctrl-C. Adds a `langgraph-checkpoint-sqlite` dependency.

Verified end-to-end: the issue's counter agent reports `1 → 3 → 5` across three `-c` invocations, and a fresh run resets to `1`.

## #104 — `langstage-cli init` scaffold (feature)
Bridges `--demo` → "run my own graph": writes a minimal, immediately-runnable `my_agent.py` (the README's keyless stdlib `StateGraph` example — needs only `langgraph`, a base dep) plus a `langstage.toml` wired to it, so the next `langstage-cli "..."` runs the user's own graph with no `-a`. Refuses to overwrite existing files unless `--force`; prints exactly what it wrote and the next step.

## #101 — `--show-config` TOML source-file attribution (fix)
When a global `~/.langstage/config.toml` and a project `langstage.toml` were both merged, the resolver stamped **every** TOML-sourced value with the last file read (the project file), so a value set only globally was mislabelled `[toml (langstage.toml)]`. The CLI now post-processes the resolved provenance, walking the same files in merge order (project wins) and relabelling each value with the highest-precedence file that actually defines its key. **cli-local** — corrects the source map the shared resolver produced without touching core.

## #103 — quiet the benign `ag_ui_langgraph` resume WARNING (fix)
Answering a plain-string `interrupt(...)` with free text made `ag_ui_langgraph` log `failed to parse resume_input as JSON, treating as string (...)` at WARNING on every response — an error-looking line above the (correct) answer, in default interactive mode. A surgical `logging.Filter` now drops **only** that one record on the emitting `ag_ui_langgraph` logger during the interactive resume (a filter on an ancestor logger isn't consulted on propagation — verified — so it targets the emitting child), so no other warning is hidden. **cli-local** — no global logging filter in core.

## Tests
+13 regression tests (one+ per issue), all hermetic (temp session store + temp config home). Also plugs a latent isolation leak: `apply_workspace` publishes `LANGSTAGE_WORKSPACE_ROOT` into `os.environ`, which a turn-running test would leak into the next test — an autouse fixture now snapshots/restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B