### PR TITLE
Fix /history on async saver + 3 config diagnostics (0.6.28: #106, #107, #108, #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.6.28 - 2026-08-03
+
+### Fixed
+- **`/history` no longer errors in the default persist-on config (gh #106).** Since
+  persistence went on by default (#102), the durable checkpointer is the async-only
+  `AsyncSqliteSaver`, opened inside each turn's own event loop and closed when the turn
+  ends. `/history` still read state via the **sync** `graph.get_state`, which against that
+  async, already-closed saver scheduled `aget_tuple` as a never-awaited coroutine and
+  surfaced `Could not retrieve history: Event loop is closed` plus a `RuntimeWarning` —
+  every user hit it on a normal run (it only worked under `--no-persist`). `/history` now
+  reads through the async API on a freshly-opened saver over the same SQLite file (mirroring
+  the run loop), so it renders the conversation on a persist-on run; the sync path still
+  serves the in-memory (`--no-persist`) case.
+- **`--show-config` names the env var you actually set for `DEEPAGENT_SPEC` (gh #107).** A
+  value supplied through the oldest legacy alias `DEEPAGENT_SPEC` was labelled
+  `[env:DEEPAGENT_AGENT_SPEC]` — the canonical-legacy key the resolver copies it onto, a
+  var absent from the environment — contradicting the command's own stderr deprecation note.
+  The `[source]` column now reports `[env:DEEPAGENT_SPEC]`, matching the note and the
+  source-accuracy fixes already done for TOML files (#101) and CLI flags (#20).
+- **A load/top-level exception with an empty message is no longer a blank, typeless
+  `Error:` (gh #109).** A bare `assert`, `raise NotImplementedError`, or `RuntimeError()`
+  has an empty `str(e)`, so the top-level handlers printed just `Error:` — no class, no
+  hint. They now name the exception class (`Error: NotImplementedError`) and point at `-v`
+  for the traceback, matching the runtime turn-error path.
+
+### Added
+- **`--show-config` surfaces the session/persistence config (gh #108, finishes #102 item
+  3).** Persistence — a headline feature, on by default with a full
+  `--persist/--no-persist` > `LANGSTAGE_PERSIST` > `[session] persist` > default chain —
+  was visible only in interactive `/status`, never in the scriptable `--show-config`.
+  `--show-config` now shows the resolved `persist` value with its `[source]`, the
+  `(env: LANGSTAGE_PERSIST, toml: session.persist)` hint, and the store path when on (in
+  both on and off states, so the off-switch is verifiable). Interactive `/config` appends
+  the identical block, so the two diagnostics can't disagree.
+
 ## 0.6.27 - 2026-07-31
 
 ### Added

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -105,6 +105,21 @@ def _status(msg: str) -> None:
     print(msg, file=sys.stderr if _QUIET else sys.stdout)
 
 
+def _fmt_exc(e: BaseException) -> str:
+    """Render an exception for a top-level ``Error:`` line, naming the class.
+
+    Many "my agent doesn't load yet" exceptions have an EMPTY ``str(e)`` — a bare
+    ``assert x`` (``AssertionError('')``), ``raise NotImplementedError``,
+    ``raise RuntimeError()`` — so a handler that prints only ``{e}`` collapsed to a
+    blank, typeless ``Error:`` with nothing to act on (gh #109). Fall back to the
+    class name when the message is empty, and prefix it otherwise, so the load/top-
+    level path names the type just like the runtime turn-error path (which core
+    renders as ``{type(exc).__name__}: {exc}``).
+    """
+    msg = str(e)
+    return f"{type(e).__name__}: {msg}" if msg else type(e).__name__
+
+
 # Keys the terminal CLI never honors, so `--show-config` / `/config` omit them and
 # the diagnostic only advertises knobs that actually do something. The inherited
 # HostConfig server keys — it starts no server (host/port/debug are inert) and the
@@ -1262,6 +1277,10 @@ def _live_resolved_report(config: Dict[str, Any], context: Dict[str, Any]) -> st
     ``/status`` and ``/config <key>``. Falls back to the frozen snapshot string only
     when the resolved cfg is unavailable (e.g. a hand-built test context).
     """
+    # The session-persistence block (gh #108), computed at startup, appended to every
+    # rendering so /config surfaces persistence exactly as --show-config does.
+    persist_block = config.get("_persist_diagnostic")
+
     resolved_cfg = config.get("_resolved_config")
     if resolved_cfg is None:
         # No live cfg to render from: honour the startup snapshot as-is, and only
@@ -1273,6 +1292,8 @@ def _live_resolved_report(config: Dict[str, Any], context: Dict[str, Any]) -> st
             report = CodeConfig.resolve().describe(
                 omit_keys=_INERT_KEYS, configurable=config.get("configurable") or None
             )
+        if persist_block:
+            report += "\n" + persist_block
         return report
 
     # Overlay the one runtime-mutable field (verbose) onto a copy, keeping every static
@@ -1295,7 +1316,10 @@ def _live_resolved_report(config: Dict[str, Any], context: Dict[str, Any]) -> st
     if isinstance(snap_conf, dict) and snap_conf:
         overlaid = {k: live_conf.get(k, v) for k, v in snap_conf.items()}
 
-    return live_cfg.describe(omit_keys=_INERT_KEYS, configurable=overlaid)
+    report = live_cfg.describe(omit_keys=_INERT_KEYS, configurable=overlaid)
+    if persist_block:
+        report += "\n" + persist_block
+    return report
 
 
 @register_command(
@@ -1354,6 +1378,25 @@ def cmd_config(args: str, context: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+async def _aget_state_via_durable_saver(graph: Any, store_path: str, config: Dict[str, Any]) -> Any:
+    """Read graph state through the ASYNC checkpointer API on a freshly-opened saver.
+
+    In the shipped persist-on default (gh #102) the durable checkpointer is an
+    ``AsyncSqliteSaver`` opened INSIDE each turn's own event loop and closed when the turn
+    ends (its aiosqlite connection can't cross loops) — so by the time ``/history`` runs
+    there is no live saver. A SYNC ``graph.get_state()`` against that async-only, already-
+    closed saver schedules ``aget_tuple()`` as a never-awaited coroutine and surfaces
+    ``Event loop is closed`` plus a ``RuntimeWarning`` (gh #106). Mirror
+    ``_run_turn_persistent``: open a fresh saver over the SAME SQLite file in THIS loop and
+    read through the async API, so ``/history`` renders on a normal persist-on run.
+    """
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+    async with AsyncSqliteSaver.from_conn_string(store_path) as saver:
+        graph.checkpointer = saver
+        return await graph.aget_state(config)
+
+
 @register_command(
     name="history",
     description="Show recent messages (if available)",
@@ -1368,46 +1411,62 @@ def cmd_history(args: str, context: Dict[str, Any]) -> Optional[str]:
         print(f"{YELLOW}No graph available{RESET}")
         return None
 
+    # The durable per-workspace store (gh #102), when persistence is on: read history
+    # through the async saver on its own loop (gh #106) instead of the sync get_state,
+    # which can't drive the closed AsyncSqliteSaver.
+    session_info = config.get("_session_info") if isinstance(config, dict) else None
+    store_path = (
+        session_info.get("store")
+        if isinstance(session_info, dict) and session_info.get("persist")
+        else None
+    )
+
     try:
-        # Try to get state from the graph's checkpointer
-        if hasattr(graph, "get_state"):
+        # Prefer the async read on the durable store; otherwise the sync path still works
+        # (an in-memory checkpointer, e.g. --no-persist, drives get_state fine).
+        state = None
+        if store_path:
+            state = asyncio.run(_aget_state_via_durable_saver(graph, store_path, config))
+        elif hasattr(graph, "get_state"):
             state = graph.get_state(config)
-            if state and hasattr(state, "values"):
-                messages = state.values.get("messages", [])
-                if messages:
-                    print(f"\n{BOLD}{BRIGHT_CYAN}Conversation History{RESET}")
-                    print(f"{DIM}{'─' * 40}{RESET}")
-
-                    # Show last N messages
-                    limit = 10
-                    if args:
-                        try:
-                            limit = int(args)
-                        except ValueError:
-                            pass
-
-                    for msg in messages[-limit:]:
-                        role = getattr(msg, "type", "unknown")
-                        content = getattr(msg, "content", str(msg))
-
-                        if role == "human":
-                            print(f"\n  {BRIGHT_BLUE}You:{RESET}")
-                        elif role == "ai":
-                            print(f"\n  {BRIGHT_CYAN}Agent:{RESET}")
-                        else:
-                            print(f"\n  {DIM}{role}:{RESET}")
-
-                        # Truncate long content
-                        if len(content) > 200:
-                            content = content[:200] + "..."
-                        print(f"  {DIM}{content}{RESET}")
-                    print()
-                else:
-                    print(f"{DIM}No messages in history{RESET}")
-            else:
-                print(f"{DIM}No state available{RESET}")
         else:
             print(f"{DIM}Graph does not support state retrieval{RESET}")
+            return None
+
+        if state and hasattr(state, "values"):
+            messages = state.values.get("messages", [])
+            if messages:
+                print(f"\n{BOLD}{BRIGHT_CYAN}Conversation History{RESET}")
+                print(f"{DIM}{'─' * 40}{RESET}")
+
+                # Show last N messages
+                limit = 10
+                if args:
+                    try:
+                        limit = int(args)
+                    except ValueError:
+                        pass
+
+                for msg in messages[-limit:]:
+                    role = getattr(msg, "type", "unknown")
+                    content = getattr(msg, "content", str(msg))
+
+                    if role == "human":
+                        print(f"\n  {BRIGHT_BLUE}You:{RESET}")
+                    elif role == "ai":
+                        print(f"\n  {BRIGHT_CYAN}Agent:{RESET}")
+                    else:
+                        print(f"\n  {DIM}{role}:{RESET}")
+
+                    # Truncate long content
+                    if len(content) > 200:
+                        content = content[:200] + "..."
+                    print(f"  {DIM}{content}{RESET}")
+                print()
+            else:
+                print(f"{DIM}No messages in history{RESET}")
+        else:
+            print(f"{DIM}No state available{RESET}")
     except Exception as e:
         print(f"{DIM}Could not retrieve history: {e}{RESET}")
 
@@ -1930,6 +1989,61 @@ def _resolve_persist(flag: Optional[bool], toml_config: dict) -> bool:
     return True
 
 
+def _persist_source_label(flag: Optional[bool], toml_config: dict) -> str:
+    """The ``[source]`` for the resolved persist value — mirrors ``_resolve_persist``'s
+    chain (``--persist/--no-persist`` > ``LANGSTAGE_PERSIST`` > ``[session] persist`` >
+    default) so ``--show-config`` attributes it just like every other key (gh #108)."""
+    if flag is not None:
+        return "override"
+    env = os.getenv("LANGSTAGE_PERSIST")
+    if env is not None and env != "":
+        return "env:LANGSTAGE_PERSIST"
+    if isinstance(config_module.get(toml_config, "session.persist"), bool):
+        return "toml (session.persist)"
+    return "default"
+
+
+def _sessions_store_source_label() -> str:
+    """The ``[source]`` for the sessions store directory (gh #108)."""
+    if os.getenv(sessions._SESSIONS_DIR_ENV):
+        return f"env:{sessions._SESSIONS_DIR_ENV}"
+    if os.getenv("LANGSTAGE_CONFIG_HOME"):
+        return "env:LANGSTAGE_CONFIG_HOME"
+    if os.getenv("DEEPAGENTS_CONFIG_HOME"):
+        return "env:DEEPAGENTS_CONFIG_HOME"
+    return "default"
+
+
+def _persist_diagnostic_block(flag: Optional[bool], toml_config: dict, workspace: Path) -> str:
+    """Render the session-persistence block appended to the config diagnostic (gh #108).
+
+    Session persistence is a headline feature (``--continue``/``--resume``, on by
+    default) with a full resolution chain, yet only interactive ``/status`` surfaced it —
+    the scriptable ``--show-config`` never did, so #102's item 3 (surface it in BOTH) was
+    half-done. ``persist`` isn't a ``CodeConfig`` field (it's resolved out-of-band by
+    ``_resolve_persist``), so it can't flow through core's ``describe()``; this renders it
+    in the SAME style right after it, and both ``--show-config`` and interactive
+    ``/config`` append this one block so the two can't disagree. The store path is
+    computed WITHOUT creating the directory (a read-only diagnostic must have no side
+    effects).
+    """
+    persist_val = _resolve_persist(flag, toml_config)
+    source = _persist_source_label(flag, toml_config)
+    lines = ["", "  Session persistence:"]
+    lines.append(
+        f"  {'persist':<16} = {str(persist_val):<26} [{source}]"
+        "   (env: LANGSTAGE_PERSIST, toml: session.persist)"
+    )
+    if persist_val:
+        # sessions_dir() reads env only (no mkdir); build the path by hand so the
+        # diagnostic never touches the filesystem the way db_path() would.
+        store = sessions.sessions_dir() / f"{sessions.workspace_key(workspace)}.sqlite"
+        lines.append(
+            f"  {'sessions_store':<16} = {str(store):<26} [{_sessions_store_source_label()}]"
+        )
+    return "\n".join(lines)
+
+
 def _format_ts(ts: Any) -> str:
     """Format an epoch timestamp for the session list; ``?`` if unparseable."""
     try:
@@ -2236,14 +2350,17 @@ def main(
         # describe() renderer, so --show-config and /config can't disagree by construction.
         _toml, _ = config_module.load_config()
         _configurable = config_module.get(_toml, "configurable")
-        print(
-            config_module.CodeConfig.resolve(
-                toml_start=Path.cwd(), overrides=cli_overrides
-            ).describe(
-                omit_keys=_INERT_KEYS,
-                configurable=_configurable if isinstance(_configurable, dict) else None,
-            )
+        _cfg = config_module.CodeConfig.resolve(toml_start=Path.cwd(), overrides=cli_overrides)
+        _diag = _cfg.describe(
+            omit_keys=_INERT_KEYS,
+            configurable=_configurable if isinstance(_configurable, dict) else None,
         )
+        # Session persistence isn't a CodeConfig field, so append it here (gh #108) — the
+        # interactive /config appends the identical block, keeping the two in lock-step.
+        _diag += "\n" + _persist_diagnostic_block(
+            persist, _toml, Path(_cfg.workspace_root).expanduser().resolve()
+        )
+        print(_diag)
         return
 
     try:
@@ -2314,6 +2431,7 @@ def main(
         # Persistence is on by default so a fresh run can be continued later; disable via
         # --no-persist / LANGSTAGE_PERSIST=0 / [session] persist=false. --continue and
         # --resume always imply it.
+        persist_flag = persist  # raw --persist/--no-persist (None if unset), for the diagnostic
         persist = _resolve_persist(persist, toml_config)
         if continue_session or resume_id is not None:
             persist = True
@@ -2400,6 +2518,12 @@ def main(
         config_dict["_snap_configurable"] = (
             _snap_configurable if isinstance(_snap_configurable, dict) else None
         )
+        # The session-persistence block interactive /config appends to the diagnostic —
+        # computed from the SAME (flag, toml, workspace) as --show-config so the two agree
+        # byte-for-byte (gh #108). Uses the raw flag (pre-forcing) to match --show-config.
+        config_dict["_persist_diagnostic"] = _persist_diagnostic_block(
+            persist_flag, toml_config, workspace
+        )
 
         # ---- Resolve the session thread + wire up persistence (gh #102) ----
         persist_sqlite_path: Optional[Path] = None
@@ -2481,21 +2605,27 @@ def main(
             pass
         sys.exit(0)
     except FileNotFoundError as e:
-        _status(f"{RED}⏺ Error: {e}{RESET}")
+        _status(f"{RED}⏺ Error: {_fmt_exc(e)}{RESET}")
         sys.exit(1)
     except AttributeError as e:
-        _status(f"{RED}⏺ Error: {e}{RESET}")
+        _status(f"{RED}⏺ Error: {_fmt_exc(e)}{RESET}")
         sys.exit(1)
     except ModuleNotFoundError as e:
-        _status(f"{RED}⏺ Error: {e}{RESET}")
+        _status(f"{RED}⏺ Error: {_fmt_exc(e)}{RESET}")
         _status(f"\n{DIM}Make sure your agent's dependencies are installed.{RESET}")
         sys.exit(1)
     except Exception as e:
-        _status(f"{RED}⏺ Error: {e}{RESET}")
+        # Name the exception class (gh #109): an empty str(e) — a bare `assert`, a
+        # `raise NotImplementedError`, `RuntimeError()` — otherwise collapsed this to a
+        # blank, typeless `Error:`. Always point at -v for the traceback, like the
+        # runtime turn-error path, so a stuck user gets something to act on.
+        _status(f"{RED}⏺ Error: {_fmt_exc(e)}{RESET}")
         if verbose:
             import traceback
 
             _status(traceback.format_exc())
+        else:
+            _status(f"{DIM}Re-run with -v for the full traceback.{RESET}")
         sys.exit(1)
 
 

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -117,6 +117,7 @@ class CodeConfig(HostConfig):
         # Reconcile the oldest legacy spec var. DEEPAGENT_AGENT_SPEC itself is
         # the shared resolver's legacy twin of LANGSTAGE_AGENT_SPEC, so mapping
         # onto it keeps the full precedence chain intact.
+        used_oldest_spec_alias = False
         if (
             not env.get("LANGSTAGE_AGENT_SPEC")
             and not env.get("DEEPAGENT_AGENT_SPEC")
@@ -135,7 +136,22 @@ class CodeConfig(HostConfig):
             # signal a real user actually sees (the stderr note) would name a variable
             # absent from their environment, defeating the deprecation nudge (gh #73).
             _warned_legacy_env.add("DEEPAGENT_AGENT_SPEC")
+            used_oldest_spec_alias = True
         obj = super().resolve(env=env, **kwargs)
+        # The shared resolver read the value out of the injected DEEPAGENT_AGENT_SPEC key
+        # and stamped its source `env:DEEPAGENT_AGENT_SPEC` — but the user only ever set
+        # DEEPAGENT_SPEC, so `--show-config` named a var absent from the environment
+        # (contradicting its own stderr note). Re-attribute the provenance to the alias
+        # that actually supplied the value, mirroring what `_warn_legacy_env` already
+        # does for the note (gh #107). Same source-accuracy fix as #101 (TOML files) and
+        # #20 (CLI flags), for the env-var alias path.
+        if used_oldest_spec_alias:
+            sources = getattr(obj, "_sources", None)
+            if (
+                isinstance(sources, dict)
+                and sources.get("agent_spec") == "env:DEEPAGENT_AGENT_SPEC"
+            ):
+                sources["agent_spec"] = "env:DEEPAGENT_SPEC"
         _correct_toml_source_file_labels(obj)
         return obj
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.27"
+version = "0.6.28"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_async_mode.py
+++ b/tests/test_async_mode.py
@@ -64,7 +64,9 @@ def test_async_mode_is_omitted_from_show_config():
     with CliRunner().isolated_filesystem():  # no stray toml
         r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output
-    assert "async_mode" not in r.output
+    # Assert the KEY is not a rendered config line (a bare substring check trips on the
+    # sessions_store path, which under pytest embeds this test's name — gh #108).
+    assert not any(ln.strip().startswith("async_mode") for ln in r.output.splitlines()), r.output
 
 
 def test_async_mode_flag_does_not_reappear_in_show_config_as_an_override():

--- a/tests/test_history_persist.py
+++ b/tests/test_history_persist.py
@@ -1,0 +1,72 @@
+"""Regression: `/history` works in the default (persist-on) config (gh #106).
+
+Since #102 persistence is on by default and the durable checkpointer is an async-only
+``AsyncSqliteSaver`` opened inside each turn's own event loop and closed when the turn
+ends. ``cmd_history`` used the SYNC ``graph.get_state`` against that async, already-closed
+saver, which scheduled ``aget_tuple`` as a never-awaited coroutine and surfaced
+"Event loop is closed" (plus a RuntimeWarning) instead of the history — every user hit it
+on a normal run. The fix reads history through the async API on a freshly-opened saver.
+
+Hermetic: conftest's autouse ``_hermetic_sessions`` points LANGSTAGE_CLI_SESSIONS_DIR at a
+temp dir, so this drives the real durable SQLite store without touching ``~/.langstage``.
+Each test scaffolds its OWN uniquely-named agent module so the module-level graph object
+is never shared across CliRunner invocations in the one pytest process (a real run is a
+fresh process; the CLI mutates ``graph.checkpointer`` per turn).
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+_ECHO_AGENT = """
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import MessagesState
+from langchain_core.messages import AIMessage
+
+
+def respond(state):
+    last = state["messages"][-1].content
+    return {"messages": [AIMessage(content=f"echo: {last}")]}
+
+
+_g = StateGraph(MessagesState)
+_g.add_node("respond", respond)
+_g.add_edge(START, "respond")
+_g.add_edge("respond", END)
+graph = _g.compile()
+"""
+
+
+def _write_agent(tmp_path, name):
+    p = tmp_path / f"{name}.py"
+    p.write_text(_ECHO_AGENT, encoding="utf-8")
+    return f"{p}:graph"
+
+
+def test_history_works_in_default_persist_on_config(tmp_path, monkeypatch):
+    # Persist is ON by default (no --no-persist): run one turn to write state to the
+    # durable async store, then /history must read it back — not error on the closed
+    # AsyncSqliteSaver.
+    monkeypatch.chdir(tmp_path)
+    spec = _write_agent(tmp_path, "hist_on_agent")
+    r = CliRunner().invoke(main, ["-a", spec], input="hello there\n/history\n/quit\n")
+    assert r.exit_code == 0, r.output
+    # The #106 symptom must be gone...
+    assert "Event loop is closed" not in r.output, r.output
+    assert "Could not retrieve history" not in r.output, r.output
+    assert "was never awaited" not in r.output, r.output
+    # ...and the command must actually render the prior turn.
+    assert "Conversation History" in r.output, r.output
+    assert "hello there" in r.output, r.output
+
+
+def test_history_still_works_with_persistence_off(tmp_path, monkeypatch):
+    # The --no-persist control from the issue: an in-memory checkpointer, so the sync
+    # read path is exercised and must keep working (no regression).
+    monkeypatch.chdir(tmp_path)
+    spec = _write_agent(tmp_path, "hist_off_agent")
+    r = CliRunner().invoke(main, ["-a", spec, "--no-persist"], input="ping\n/history\n/quit\n")
+    assert r.exit_code == 0, r.output
+    assert "Event loop is closed" not in r.output, r.output
+    assert "Conversation History" in r.output, r.output
+    assert "ping" in r.output, r.output

--- a/tests/test_load_error.py
+++ b/tests/test_load_error.py
@@ -1,0 +1,38 @@
+"""Regression: a load/top-level exception with an empty ``str(e)`` is not blank (gh #109).
+
+A bare ``assert x`` (``AssertionError('')``), ``raise NotImplementedError``, or
+``RuntimeError()`` has an empty string representation, so the top-level handlers — which
+printed only ``{e}`` — collapsed to a blank, typeless ``Error:`` with no class name and
+no ``-v`` hint (strictly worse than, and inconsistent with, the runtime turn-error path,
+which names the type). The fix names the exception class and always points at ``-v``.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_top_level_empty_message_exception_names_class_and_hints_at_v(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # A realistic "my agent doesn't load yet" trigger: a module that raises with no message.
+    (tmp_path / "boom_agent.py").write_text(
+        "raise NotImplementedError\ngraph = None\n", encoding="utf-8"
+    )
+
+    r = CliRunner().invoke(main, ["-a", "boom_agent.py:graph", "hi"])
+    assert r.exit_code == 1, r.output
+    # The class name appears even though str(e) == "" (the old blank `Error:` is gone)...
+    assert "Error: NotImplementedError" in r.output, r.output
+    # ...and the same -v nudge the user needs to get the traceback.
+    assert "-v" in r.output, r.output
+
+
+def test_top_level_bare_assert_is_not_a_blank_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "assert_agent.py").write_text("assert False\ngraph = None\n", encoding="utf-8")
+
+    r = CliRunner().invoke(main, ["-a", "assert_agent.py:graph", "hi"])
+    assert r.exit_code == 1, r.output
+    assert "Error: AssertionError" in r.output, r.output
+    # never a bare, typeless "Error:" line
+    assert not any(ln.strip() in ("Error:", "⏺ Error:") for ln in r.output.splitlines()), r.output

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -127,3 +127,53 @@ def test_show_config_title_env_not_advertised_as_effective():
     assert r.exit_code == 0, r.output
     assert "MyCoolAgent" not in r.output
     assert not re.search(r"^\s*title\s*=", r.output, re.MULTILINE)
+
+
+def test_show_config_attributes_deepagent_spec_to_the_var_actually_set():
+    """gh #107: a value set via the oldest legacy alias DEEPAGENT_SPEC must be attributed
+    to DEEPAGENT_SPEC — the var the user actually set — not to DEEPAGENT_AGENT_SPEC, the
+    canonical-legacy key the resolver copies it onto (a var absent from the environment,
+    contradicting --show-config's own stderr deprecation note)."""
+    with CliRunner().isolated_filesystem():  # no stray toml / other spec vars
+        r = CliRunner().invoke(main, ["--show-config"], env={"DEEPAGENT_SPEC": "my_agent.py:graph"})
+    assert r.exit_code == 0, r.output
+    # The [source] column names the var the user set...
+    assert re.search(r"agent_spec\s*=\s*my_agent\.py:graph\s*\[env:DEEPAGENT_SPEC\]", r.output), (
+        r.output
+    )
+    # ...and never the injected canonical-legacy key that was never in the environment.
+    assert "[env:DEEPAGENT_AGENT_SPEC]" not in r.output, r.output
+
+
+def test_show_config_surfaces_session_persistence_on(tmp_path, monkeypatch):
+    """gh #108: --show-config (the scriptable inspector) must surface the persist/session
+    config the way interactive /status does — persistence on/off, its source, store path —
+    finishing #102 item 3. Default config: persistence ON."""
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    assert "Session persistence:" in r.output, r.output
+    assert re.search(r"persist\s*=\s*True\s*\[default\]", r.output), r.output
+    # the source hint, matching describe()'s style
+    assert "(env: LANGSTAGE_PERSIST, toml: session.persist)" in r.output, r.output
+    # the store path is shown when persistence is on
+    assert re.search(r"sessions_store\s*=\s*\S+\.sqlite", r.output), r.output
+
+
+def test_show_config_surfaces_persist_off_so_the_off_switch_is_verifiable(tmp_path, monkeypatch):
+    """gh #108: --no-persist must be visible in --show-config so "did my off-switch work?"
+    is answerable from the scriptable surface (it isn't from /status, which only prints
+    Persist: when persistence is ON)."""
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--no-persist", "--show-config"])
+    assert r.exit_code == 0, r.output
+    assert re.search(r"persist\s*=\s*False\s*\[override\]", r.output), r.output
+
+
+def test_show_config_persist_source_is_the_toml_key_when_set_there(tmp_path, monkeypatch):
+    """gh #108: [session] persist in langstage.toml is attributed to the TOML key."""
+    (tmp_path / "langstage.toml").write_text("[session]\npersist = false\n")
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    assert re.search(r"persist\s*=\s*False\s*\[toml \(session\.persist\)\]", r.output), r.output

--- a/tests/test_stream_mode.py
+++ b/tests/test_stream_mode.py
@@ -48,7 +48,9 @@ def test_stream_mode_is_omitted_from_show_config():
     # gh #62: the deprecated no-op knob is no longer advertised in --show-config.
     r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output
-    assert "stream_mode" not in r.output
+    # Assert the KEY is not a rendered config line (a bare substring check trips on the
+    # sessions_store path, which under pytest embeds this test's name — gh #108).
+    assert not any(ln.strip().startswith("stream_mode") for ln in r.output.splitlines()), r.output
 
 
 def test_stream_mode_flag_is_accepted_and_ignored_with_a_notice():


### PR DESCRIPTION
Ships **0.6.28** fixing four cli-local issues in one release. One regression test per issue; full suite green; `ruff check` + `ruff format --check` clean.

## #106 (bug, regression from #102) — `/history` throws "Event loop is closed"
In the shipped persist-on default the durable checkpointer is the async-only `AsyncSqliteSaver`, opened inside each turn's own event loop and closed when the turn ends. `cmd_history` read state via the **sync** `graph.get_state`, which against that async, already-closed saver scheduled `aget_tuple` as a never-awaited coroutine and surfaced `Could not retrieve history: Event loop is closed` + a `RuntimeWarning` — every user hit it (only `--no-persist` worked). Now reads through the async API (`aget_state`) on a freshly-opened saver over the same SQLite file, mirroring the run loop; the sync path still serves the in-memory case.

## #107 (bug) — `--show-config` mislabels the source of `DEEPAGENT_SPEC`
A value set via the oldest legacy alias `DEEPAGENT_SPEC` was labelled `[env:DEEPAGENT_AGENT_SPEC]` — the canonical-legacy key the resolver copies it onto, absent from the environment, contradicting the command's own stderr note. The `[source]` column now reports `[env:DEEPAGENT_SPEC]` (re-attributed in `CodeConfig.resolve`, same class of fix as #101/#20).

## #108 (enhancement, finishes #102 item 3) — `--show-config` never surfaced persist/session config
Persistence was visible only in interactive `/status`. `--show-config` now shows the resolved `persist` value with its `[source]`, the `(env: LANGSTAGE_PERSIST, toml: session.persist)` hint, and the store path when on — in both on and off states, so the off-switch is verifiable. Interactive `/config` appends the identical block so the two can't diverge.

## #109 (bug) — blank, typeless `Error:` on an empty-message load exception
A bare `assert` / `raise NotImplementedError` / `RuntimeError()` has an empty `str(e)`, so the top-level handlers printed just `Error:`. They now name the exception class (`Error: NotImplementedError`) and point at `-v`, matching the runtime turn-error path.

## Tests
- `tests/test_history_persist.py` (#106), `tests/test_load_error.py` (#109), and new `tests/test_show_config.py` cases (#107, #108). Each verified to fail pre-fix and pass post-fix.
- Tightened two over-broad `"stream_mode"/"async_mode" not in output` substring checks (they now trip on the sessions_store path, which under pytest embeds the test name) to precise line checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B