### PR TITLE
fix: --show-config stops flagging documented [session] persist as an unknown TOML key (gh #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.29 - 2026-08-06
+
+### Fixed
+- **`--show-config` no longer flags the documented `[session] persist` key as an "unknown
+  TOML key" (gh #112).** `langstage-core` 1.0.32 added unknown-TOML-key detection
+  (`HostConfig.unknown_toml_keys()`, surfaced in `--show-config`), which flags any TOML key
+  that maps to no config field. `persist` is resolved out-of-band by `_resolve_persist`
+  (flag > `LANGSTAGE_PERSIST` > `[session] persist` > default-on), so it isn't a `CodeConfig`
+  dataclass field — and the detector wrongly listed the documented, honored `session.persist`
+  under "unknown TOML keys (ignored - a typo or wrong table?)", in the very same output that
+  attributed `persist = ... [toml (session.persist)]` to it. `CodeConfig._TOML` now registers
+  `session.persist` in the known-key set so it stops being false-flagged. It's a map entry,
+  not a field, so `persist` stays resolved out-of-band and rendered by its own block (no
+  double-render). A genuine typo like `[session] perssist` (or any unknown table) is still
+  flagged — the detector isn't disabled, only the false positive is removed.
+
 ## 0.6.28 - 2026-08-03
 
 ### Fixed

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -109,6 +109,18 @@ class CodeConfig(HostConfig):
     _TOML: ClassVar[dict] = {
         "graph_name": "agent.graph_name",
         "verbose": "ui.verbose",
+        # session.persist has no CodeConfig FIELD — persist is resolved out-of-band by
+        # cli._resolve_persist (flag > LANGSTAGE_PERSIST > [session] persist > default-on)
+        # and rendered by its own --show-config block (gh #102/#108). But core's
+        # unknown_toml_keys() flags any TOML key absent from _toml_map(), so post-#108
+        # --show-config wrongly listed the documented, honored [session] persist under
+        # "unknown TOML keys" — in the same output that attributes persist to it (gh #112).
+        # Registering the dotted key here adds it to the KNOWN set so it's no longer flagged.
+        # It's a map entry, not a field: resolve()/describe()/config_dict() iterate dataclass
+        # fields, so this neither creates a phantom field nor double-renders persist — while a
+        # typo like [session] perssist (absent from the map, not a passthrough) is still flagged.
+        # A [session] passthrough would instead silence the WHOLE table, hiding real typos.
+        "persist": "session.persist",
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.28"
+version = "0.6.29"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -177,3 +177,33 @@ def test_show_config_persist_source_is_the_toml_key_when_set_there(tmp_path, mon
     r = CliRunner().invoke(main, ["--show-config"])
     assert r.exit_code == 0, r.output
     assert re.search(r"persist\s*=\s*False\s*\[toml \(session\.persist\)\]", r.output), r.output
+
+
+def test_show_config_does_not_flag_documented_session_persist_as_unknown(tmp_path, monkeypatch):
+    """gh #112: [session] persist is a documented, honored key, so --show-config must NOT
+    list it under "unknown TOML keys" — in the exact output that attributes persist to it.
+
+    Regression for the post-#108 gap: core's unknown_toml_keys() flagged session.persist
+    because it isn't a CodeConfig dataclass field (persist is resolved out-of-band). The fix
+    registers session.persist in CodeConfig._TOML's known set so it stops being false-flagged,
+    while genuine typos stay flagged (asserted below)."""
+    (tmp_path / "langstage.toml").write_text("[session]\npersist = true\n")
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    # The documented key must NOT be reported as unknown...
+    assert "unknown TOML keys" not in r.output, r.output
+    assert "session.persist" not in r.output.split("Session persistence:")[0], r.output
+    # ...yet it is still honored and attributed to its TOML source (the two lines agree now).
+    assert re.search(r"persist\s*=\s*True\s*\[toml \(session\.persist\)\]", r.output), r.output
+
+
+def test_show_config_still_flags_a_typod_session_key_as_unknown(tmp_path, monkeypatch):
+    """gh #112: the fix must NOT disable the unknown-key detector — a typo'd key under the
+    same [session] table (perssist) and a bogus table must still be surfaced as unknown."""
+    (tmp_path / "langstage.toml").write_text("[session]\nperssist = true\n[bogus]\nx = 1\n")
+    monkeypatch.chdir(tmp_path)
+    r = CliRunner().invoke(main, ["--show-config"])
+    assert r.exit_code == 0, r.output
+    assert re.search(r"unknown TOML keys.*session\.perssist", r.output), r.output
+    assert re.search(r"unknown TOML keys.*bogus\.x", r.output), r.output


### PR DESCRIPTION
## Summary

Fixes #112. `langstage-cli --show-config` contradicted itself about `[session] persist`: in one run it listed `session.persist` under **"unknown TOML keys (ignored - a typo or wrong table?)"** and, one line later, attributed `persist = ... [toml (session.persist)]` to that same key.

`[session] persist` is a **documented** key (README: disable persistence with `[session] persist = false`) and it **is honored** — so the "unknown/typo/ignored" warning is a false positive on the very diagnostic verb a user runs to *trust* their config.

## Root cause

`langstage-core` 1.0.32 added unknown-TOML-key detection (`HostConfig.unknown_toml_keys()`), which flags any TOML key that maps to no config field. `persist` is resolved **out-of-band** by `cli._resolve_persist` (flag > `LANGSTAGE_PERSIST` > `[session] persist` > default-on) and rendered by its own `--show-config` block (gh #102/#108), so it is deliberately **not** a `CodeConfig` dataclass field — hence absent from `_toml_map()` and false-flagged.

## The fix

Register the dotted key `session.persist` in `CodeConfig._TOML`'s known-key set. This is a **map entry, not a dataclass field** — core's `resolve()` / `describe()` / `config_dict()` all iterate dataclass *fields*, so this adds no phantom field and does **not** double-render `persist`; it stays resolved and rendered out-of-band exactly as before.

A `_TOML_PASSTHROUGH` `[session]` table was rejected on purpose: it would silence the **whole** table and hide real typos. Registering the single key keeps the detector honest — a typo like `[session] perssist` (or any unknown table `[bogus] x`) is **still flagged**.

## Verification

| `langstage.toml` | Before | After |
|---|---|---|
| `[session] persist = false` | flagged as unknown ❌ | not flagged ✓, `persist = False [toml (session.persist)]` |
| `[session] perssist = true` | flagged | still flagged ✓ |
| `[bogus] x = 1` | flagged | still flagged ✓ |

## Tests

- Full suite: **176 passed**, ruff `check` + `format --check` clean.
- Adds two regression tests in `tests/test_show_config.py`: documented `[session] persist` shows no unknown-key warning; typo'd `[session] perssist` and `[bogus] x` are still flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B