### PR TITLE
fix: toml-relative agent spec resolves against toml dir + clean TypeError for wrong-type graph on default path (gh #116, #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.6.30 - 2026-08-08
+
+### Fixed
+- **A relative `agent.spec` in `langstage.toml` now resolves against the toml's own
+  directory, so an `init`-scaffolded project runs from any subdirectory (gh #116).**
+  Config discovery walks UP ancestor dirs to find `langstage.toml` (a project-root
+  concept, so you can run the CLI from anywhere in your project), but a relative
+  `agent.spec` in it — exactly what `init` scaffolds (`spec = "my_agent.py:graph"`) —
+  was resolved against the process **cwd**. So the moment you ran from a subdirectory the
+  spec was looked up under that subdir and crashed `Agent file not found`, even though
+  `--show-config` (walking up correctly) reported the spec resolved. A relative spec that
+  came from a discovered `langstage.toml` now rebases onto **that toml's directory** (the
+  project root) before loading — the same way a path in `pyproject.toml` / `tsconfig.json`
+  resolves relative to the config file — so the project runs identically from its root and
+  any subdirectory. A spec from `-a` / `LANGSTAGE_AGENT_SPEC` keeps its cwd-relative base
+  ("the file is where the user typed the command", gh #30); only toml-sourced relative
+  specs change base. The `path:attr` split stays Windows drive-letter safe (`C:\x.py:graph`).
+- **A wrong-type agent object now shows `build_agent`'s clean `TypeError` on the default
+  persist-on run path, not a cryptic `AttributeError: 'X' object has no attribute
+  'checkpointer'` (gh #117).** When the resolved agent isn't a compiled graph (`graph =
+  None`, a dict, an int — a placeholder, a construction that fell through, or `-a` pointed
+  at the wrong attribute), the default path attaches the durable `AsyncSqliteSaver` (#102)
+  by setting `graph.checkpointer` **before** `build_agent` validates the graph — so the
+  attribute-set raised first and leaked an internal `AttributeError`. `--verify` and
+  `--no-persist` already reached `build_agent`'s actionable `TypeError: build_agent expected
+  a compiled LangGraph graph (CompiledStateGraph) ... but got NoneType.`; the default config
+  (which every user hits) now does too. The durable saver assignment is guarded exactly like
+  the non-durable `_ensure_checkpointer`, so a valid graph is unaffected and the wrong-type
+  object falls through to the one clean validator message.
+
 ## 0.6.29 - 2026-08-06
 
 ### Fixed

--- a/langstage_cli/cli.py
+++ b/langstage_cli/cli.py
@@ -678,6 +678,30 @@ def _ensure_checkpointer(graph: Any) -> None:
         pass
 
 
+def _split_py_file_spec(spec: str) -> Optional[Tuple[str, str]]:
+    """Split a ``path.py[:attr]`` agent spec into ``(file_path, suffix)`` when the
+    path part is a ``.py`` FILE path; return ``None`` for module specs / non-specs.
+
+    ``suffix`` is the reattachable ``":attr"`` (or ``""`` for a bare path). The
+    ``path:attr`` split is the same one ``load_graph`` uses and stays Windows
+    drive-letter safe: a trailing ``':token'`` is a graph-name suffix only when it
+    has no path separator, so ``C:\\x.py:graph`` keeps its drive colon and splits at
+    the final ``:graph``. Shared by ``_absolutize_file_spec`` (cwd base, gh #30) and
+    ``_rebase_toml_file_spec`` (toml-dir base, gh #116) so the parse lives in one place.
+    """
+    if not spec:
+        return None
+    path_part, suffix = spec, ""
+    if ":" in spec:
+        head, _, tail = spec.rpartition(":")
+        if tail and "/" not in tail and "\\" not in tail:
+            path_part, suffix = head, f":{tail}"
+    # Only a .py file path is a resolvable file; a module path (pkg.mod) is not.
+    if not path_part.endswith(".py"):
+        return None
+    return path_part, suffix
+
+
 def _absolutize_file_spec(spec: str) -> str:
     """Resolve a relative *file-path* agent spec to an absolute path against the
     current cwd.
@@ -689,19 +713,37 @@ def _absolutize_file_spec(spec: str) -> str:
     the invocation cwd. Module specs (``pkg.mod:attr``) and already-absolute
     paths pass through unchanged. (gh #30)
     """
-    if not spec:
+    parsed = _split_py_file_spec(spec)
+    if parsed is None:
         return spec
-    path_part, suffix = spec, ""
-    if ":" in spec:
-        head, _, tail = spec.rpartition(":")
-        # Same rule as load_graph: a trailing ':token' with no path separator is
-        # a graph name, not part of a Windows drive path.
-        if tail and "/" not in tail and "\\" not in tail:
-            path_part, suffix = head, f":{tail}"
-    # Only a .py file path is workspace-relative; a module path is not a file.
-    if path_part.endswith(".py"):
-        return f"{Path(path_part).expanduser().resolve()}{suffix}"
-    return spec
+    path_part, suffix = parsed
+    return f"{Path(path_part).expanduser().resolve()}{suffix}"
+
+
+def _rebase_toml_file_spec(spec: str, toml_dir: Path) -> str:
+    """Resolve a relative *file-path* agent spec that came from a ``langstage.toml``
+    against that toml's OWN directory — the discovered project root — not the cwd.
+
+    Config discovery walks UP to find ``langstage.toml``, but a relative ``agent.spec``
+    in it (what ``init`` scaffolds, e.g. ``"my_agent.py:graph"``) was resolved against
+    the process cwd, so running from a subdir crashed ``Agent file not found`` even
+    though ``--show-config`` reported the spec resolved. A toml-sourced relative spec's
+    natural base is the config file's directory — like a path in ``pyproject.toml`` /
+    ``tsconfig.json`` resolves relative to the config file — so the project runs
+    identically from its root and any subdirectory. (gh #116)
+
+    Only applied to *toml-sourced* specs; specs from ``-a`` / ``LANGSTAGE_AGENT_SPEC``
+    keep #30's cwd-relative base ("where the user typed it"). Module specs
+    (``pkg.mod:attr``) and already-absolute paths pass through unchanged.
+    """
+    parsed = _split_py_file_spec(spec)
+    if parsed is None:
+        return spec
+    path_part, suffix = parsed
+    file_path = Path(path_part).expanduser()
+    if file_path.is_absolute():
+        return spec
+    return f"{(toml_dir / file_path).resolve()}{suffix}"
 
 
 def get_tool_arg_preview(args: Dict[str, Any]) -> str:
@@ -1694,7 +1736,19 @@ async def _run_turn_persistent(
     from langstage_cli.agui_stream import build_session_agent
 
     async with AsyncSqliteSaver.from_conn_string(str(sqlite_path)) as saver:
-        graph.checkpointer = saver
+        # Attach the durable saver, but GUARD the assignment the way _ensure_checkpointer
+        # does. A wrong-type agent object (graph = None / a dict / an int — not a compiled
+        # graph) rejects the attribute set, and on this default persist-on path that used
+        # to leak a cryptic `AttributeError: 'X' object has no attribute 'checkpointer'`
+        # BEFORE any validation ran. Swallowing it lets the object fall through to
+        # build_session_agent -> build_agent, whose validator raises the clean, actionable
+        # `TypeError: build_agent expected a compiled LangGraph graph ...` — the same
+        # message --verify / --no-persist already show. A valid graph accepts the
+        # assignment, so durable persistence is unchanged. (gh #117)
+        try:
+            graph.checkpointer = saver
+        except Exception:  # noqa: BLE001 - defer to build_agent's clean type validation below
+            pass
         agent = build_session_agent(graph, name=name, config=session_config)
         return await run_single_turn_agui(agent, message, thread_id, interactive, verbose)
 
@@ -2449,10 +2503,24 @@ def main(
                 _status(f"\n{DIM}Or set the LANGSTAGE_AGENT_SPEC environment variable{RESET}")
                 sys.exit(1)
 
-        # Resolve a relative file-path spec against the invocation cwd BEFORE we
-        # chdir into the workspace root — otherwise `-a my_agent.py` is looked up
-        # under workspace_root, not where the user is and put the file. (gh #30)
-        final_spec = _absolutize_file_spec(final_spec)
+        # Resolve a relative file-path spec to an absolute path BEFORE we chdir into
+        # the workspace root — otherwise it's looked up under workspace_root, not where
+        # the file is. The BASE directory depends on WHERE the spec came from:
+        #   - a spec from a discovered `langstage.toml` resolves against THAT toml's own
+        #     directory (the project root the walk-up found), like a path in
+        #     pyproject.toml / tsconfig — so the project runs identically from its root
+        #     and any subdirectory (gh #116);
+        #   - a spec from `-a` / `LANGSTAGE_AGENT_SPEC` (or the built-in default) stays
+        #     cwd-relative — "the file is where the user typed the command" (gh #30).
+        spec_toml_dir = (
+            config_module.toml_dir_for(cfg, "agent_spec")
+            if cfg.sources.get("agent_spec", "").startswith("toml")
+            else None
+        )
+        if spec_toml_dir is not None:
+            final_spec = _rebase_toml_file_spec(final_spec, spec_toml_dir)
+        else:
+            final_spec = _absolutize_file_spec(final_spec)
 
         # Apply the resolved workspace as the single source of truth (ADR 0005):
         # publish it (env + active) so the agent's tools can read workspace_root(),

--- a/langstage_cli/config.py
+++ b/langstage_cli/config.py
@@ -168,6 +168,35 @@ class CodeConfig(HostConfig):
         return obj
 
 
+def toml_dir_for(cfg: HostConfig, field_name: str) -> Optional[Path]:
+    """Directory of the merged ``langstage.toml`` that actually DEFINES ``field_name``.
+
+    Config discovery walks UP ancestor dirs to find ``langstage.toml`` (a project-root
+    concept), so a relative path declared in it — e.g. ``init``'s ``agent.spec =
+    "my_agent.py:graph"`` — must resolve against the directory that CONTAINS the toml
+    (the discovered project root), not the process cwd, the same way a path in
+    ``pyproject.toml`` / ``tsconfig.json`` resolves relative to the config file. This
+    returns that directory so the caller can rebase the relative value. (gh #116)
+
+    A global ``~/.langstage/config.toml`` and a project ``langstage.toml`` may both be
+    merged; the winning file is the highest-precedence (last) one that actually defines
+    the field's dotted key — mirroring the winner-finding in ``HostConfig.resolve`` and
+    ``_correct_toml_source_file_labels``. Returns ``None`` when the field isn't
+    TOML-mapped or no read file defines it.
+    """
+    toml_paths = getattr(cfg, "_toml_paths", None)
+    if not toml_paths:
+        return None
+    dotted = type(cfg)._toml_map().get(field_name)
+    if dotted is None:
+        return None
+    winner: Optional[Path] = None
+    for path in toml_paths:
+        if _get_dotted(_read_toml(path), dotted) is not None:
+            winner = path
+    return winner.parent if winner is not None else None
+
+
 def _correct_toml_source_file_labels(cfg: HostConfig) -> None:
     """Re-attribute each TOML-sourced value to the file it ACTUALLY came from (gh #101).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langstage-cli"
-version = "0.6.29"
+version = "0.6.30"
 description = "The terminal stage for your LangGraph agent — Claude Code-style CLI for any CompiledGraph"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -61,3 +61,65 @@ def test_relative_spec_with_workspace_root_resolves_against_cwd(tmp_path, monkey
     assert r.exit_code == 0, r.output
     assert "hi from my_agent" in r.output
     assert "not found" not in r.output.lower()
+
+
+# ── gh #116: a RELATIVE spec from a walked-up langstage.toml resolves against the
+# toml's own directory (the project root), so an init-scaffolded project runs from
+# any subdirectory — not just its root. Distinct from #30 (a -a/env spec stays
+# cwd-relative), which the tests above and below pin. ──────────────────────────
+
+
+def test_toml_relative_spec_resolves_against_toml_dir_from_subdir(tmp_path, monkeypatch):
+    """gh #116: the documented `init` scaffold runs from a subdir, not just its root.
+
+    `init` writes a RELATIVE `agent.spec` ("my_agent.py:graph") at the project root.
+    Config discovery walks UP to find that langstage.toml from a subdir, so the spec
+    must resolve against the toml's OWN directory (the project root) — not the process
+    cwd — else the run crashes `Agent file not found` from any subdirectory.
+    """
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    # Scaffold the documented init project at the root (my_agent.py + langstage.toml).
+    monkeypatch.chdir(proj)
+    assert CliRunner().invoke(main, ["init"]).exit_code == 0
+
+    # From the project ROOT the run already works today...
+    monkeypatch.chdir(proj)
+    r_root = CliRunner().invoke(main, ["--no-interactive", "hello from root"])
+    assert r_root.exit_code == 0, r_root.output
+    assert "You said: hello from root" in r_root.output
+
+    # ...and from a normal SUBDIR of the same project it must work too (the bug).
+    sub = proj / "src"
+    sub.mkdir()
+    monkeypatch.chdir(sub)
+    r_sub = CliRunner().invoke(main, ["--no-interactive", "hello from src"])
+    assert r_sub.exit_code == 0, r_sub.output
+    assert "You said: hello from src" in r_sub.output
+    assert "not found" not in r_sub.output.lower()
+
+
+def test_dash_a_relative_spec_stays_cwd_relative_from_subdir(tmp_path, monkeypatch):
+    """gh #116 control: `-a` keeps #30's cwd-relative base even beside a langstage.toml.
+
+    Only TOML-sourced specs rebase onto the toml dir; a spec the user types on the
+    command line resolves against where they typed it. Here the toml points at a
+    DIFFERENT file at the root, but `-a my_agent.py:graph` from a subdir loads the
+    subdir's file — proving the -a base is the cwd, not the toml dir.
+    """
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "langstage.toml").write_text('[agent]\nspec = "root_agent.py:graph"\n')
+    (proj / "root_agent.py").write_text(_AGENT_SRC)
+    sub = proj / "src"
+    sub.mkdir()
+    (sub / "my_agent.py").write_text(_AGENT_SRC)
+    monkeypatch.chdir(sub)
+
+    r = CliRunner().invoke(main, ["-a", "my_agent.py:graph", "--no-interactive", "hi"])
+    assert r.exit_code == 0, r.output
+    assert "hi from my_agent" in r.output
+    assert "not found" not in r.output.lower()

--- a/tests/test_wrong_type_graph.py
+++ b/tests/test_wrong_type_graph.py
@@ -1,0 +1,31 @@
+"""gh #117: a wrong-type agent object gets build_agent's clean TypeError on the
+DEFAULT (persist-on) run path, not a cryptic leaked internal AttributeError.
+
+The default path attaches a durable AsyncSqliteSaver (gh #102) by setting
+`graph.checkpointer` BEFORE `build_agent` validates the graph. For `graph = None`
+(a placeholder, a construction that fell through, or `-a` pointed at the wrong
+attribute) that attribute-set raised first, leaking
+`AttributeError: 'NoneType' object has no attribute 'checkpointer'`. `--verify` and
+`--no-persist` already reached build_agent's clean, actionable message — the default
+config, which every user hits, must too.
+"""
+
+from click.testing import CliRunner
+
+from langstage_cli.cli import main
+
+
+def test_none_graph_default_path_shows_clean_typeerror(tmp_path, monkeypatch):
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(tmp_path / "empty_home"))
+    (tmp_path / "nonegraph.py").write_text("graph = None\n")
+    monkeypatch.chdir(tmp_path)
+
+    # DEFAULT config: persistence ON (no --no-persist / --verify).
+    r = CliRunner().invoke(main, ["-a", "nonegraph.py:graph", "--no-interactive", "hi"])
+
+    assert r.exit_code != 0, r.output
+    # build_agent's clean, actionable validator message — the same one --verify shows.
+    assert "build_agent expected a compiled LangGraph graph" in r.output, r.output
+    assert "but got NoneType" in r.output, r.output
+    # The cryptic internal leak must be gone.
+    assert "has no attribute 'checkpointer'" not in r.output, r.output


### PR DESCRIPTION
Ships **0.6.30**, fixing two cli-local bugs.

## #116 — relative `agent.spec` in `langstage.toml` resolved against cwd, not the toml's dir
Config discovery walks UP ancestor dirs to find `langstage.toml`, but a relative `agent.spec` in it (what `init` scaffolds: `spec = "my_agent.py:graph"`) was resolved against the process **cwd**. So running from a subdirectory crashed `Agent file not found` even though `--show-config` reported the spec resolved.

**Fix:** a relative file spec whose source is a discovered `langstage.toml` now rebases onto **that toml's own directory** (the project root) before loading — the same way a path in `pyproject.toml` / `tsconfig.json` resolves relative to the config file. A spec from `-a` / `LANGSTAGE_AGENT_SPEC` keeps its cwd-relative base (#30 — "the file is where the user typed it"); only toml-sourced relative specs change base. The `path:attr` split is factored into `_split_py_file_spec` (Windows drive-letter safe — `C:\x.py:graph`) and reused by both `_absolutize_file_spec` (cwd) and the new `_rebase_toml_file_spec` (toml dir); `config.toml_dir_for` finds the merged file that actually defines the key.

## #117 — wrong-type agent leaked `AttributeError: '...' object has no attribute 'checkpointer'` on the DEFAULT path
On the default persist-on path, a wrong-type agent object (`graph = None`, a dict, an int) crashed with a cryptic `AttributeError` because the durable `AsyncSqliteSaver` was assigned to `graph.checkpointer` **before** `build_agent` validated the graph. `--verify` and `--no-persist` already showed the clean message.

**Fix:** the durable saver assignment is guarded exactly like the non-durable `_ensure_checkpointer` (`try/except`), so a wrong-type object falls through to `build_agent`'s actionable `TypeError: build_agent expected a compiled LangGraph graph (CompiledStateGraph) ... but got NoneType.` — matching `--verify` / `--no-persist`. Valid graphs are unaffected.

## Tests
- `test_spec_resolution.py`: init-scaffold runs from a subdir (spec resolved against the toml dir); `-a` stays cwd-relative alongside a `langstage.toml` (control).
- `test_wrong_type_graph.py`: `graph = None` on the default config shows the clean `TypeError`, not the checkpointer leak, and exits non-zero.
- Full suite: **177 passed**. `ruff check` + `ruff format --check` clean.

Closes #116, closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B